### PR TITLE
[Refactor] CORS 누락으로 인한 로그인 요청 차단 해결

### DIFF
--- a/src/main/java/com/clover/salad/security/WebSecurity.java
+++ b/src/main/java/com/clover/salad/security/WebSecurity.java
@@ -1,5 +1,7 @@
 package com.clover.salad.security;
 
+import static org.springframework.security.config.Customizer.*;
+
 import java.util.Collections;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +49,7 @@ public class WebSecurity {
 		AuthenticationManager manager = authenticationManager();
 
 		http.csrf(csrf -> csrf.disable());
+		http.cors(withDefaults());
 
 		http.authorizeHttpRequests(authz ->
 				authz


### PR DESCRIPTION
## 📌연관된 이슈

> close #155 

## 📝작업 내용

> Spring Security에서 CORS 설정을 반영하기 위해 `http.cors(withDefaults())` 추가

- 기존에 WebConfig에서 설정한 `allowedOrigins`, `allowCredentials` 등이 Security 레벨에서 적용되지 않아 preflight 요청이 차단되는 문제
- `http.cors()`를 통해 SecurityFilterChain에서도 해당 설정을 인식하도록 설정 추가

### 스크린샷 (선택)

