### PR TITLE
[Feat] 로그인 시 헤더에 표시할 사용자 정보까지 한 번에 조회하는 기능 구현

### DIFF
--- a/src/main/java/com/clover/salad/common/file/entity/FileUploadEntity.java
+++ b/src/main/java/com/clover/salad/common/file/entity/FileUploadEntity.java
@@ -37,5 +37,7 @@ public class FileUploadEntity {
 
 	@Column(name = "created_at")
 	private LocalDateTime createdAt;
+
+	@Column(name = "type")
 	private String type; // 예: 계약서
 }

--- a/src/main/java/com/clover/salad/employee/command/application/controller/AuthController.java
+++ b/src/main/java/com/clover/salad/employee/command/application/controller/AuthController.java
@@ -1,0 +1,65 @@
+package com.clover.salad.security;
+
+import com.clover.salad.employee.command.domain.aggregate.vo.RequestLoginVO;
+import com.clover.salad.employee.command.domain.aggregate.entity.EmployeeEntity;
+import com.clover.salad.employee.command.domain.repository.EmployeeRepository;
+import com.clover.salad.employee.query.dto.LoginHeaderInfoDTO;
+import com.clover.salad.employee.query.dto.LoginResponseDTO;
+import com.clover.salad.employee.query.service.EmployeeQueryService;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final EmployeeRepository employeeRepository;
+	private final EmployeeQueryService employeeQueryService;
+	private final JwtUtil jwtUtil;
+	private final PasswordEncoder passwordEncoder;
+
+	@PostMapping("/login")
+	public ResponseEntity<LoginResponseDTO> login(@RequestBody RequestLoginVO request,
+		HttpServletResponse response) {
+
+		// 1. 사용자 검증
+		EmployeeEntity employee = employeeRepository.findByCode(request.getCode())
+			.orElseThrow(() -> new RuntimeException("해당 사번을 가진 사용자가 없습니다."));
+
+		if (!passwordEncoder.matches(request.getPassword(), employee.getEncPwd())) {
+			throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+		}
+
+		// 2. 권한 포함 accessToken 생성
+		UserDetails userDetails = employeeQueryService.loadUserByUsername(employee.getCode());
+		String accessToken = jwtUtil.createAccessToken(userDetails.getUsername(), userDetails.getAuthorities());
+
+		// 3. refreshToken은 HttpOnly 쿠키로 전송
+		String refreshToken = jwtUtil.createRefreshToken(employee.getCode());
+
+		ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+			.httpOnly(true)
+			.secure(true)
+			.sameSite("Strict")
+			.path("/")
+			.maxAge(Duration.ofHours(8))
+			.build();
+		response.addHeader("Set-Cookie", cookie.toString());
+
+		// 4. 사용자 표시 정보 조회 (쿼리 기반)
+		LoginHeaderInfoDTO headerInfo = employeeQueryService.getLoginHeaderInfo(employee.getCode());
+
+		// 5. 응답 구성
+		return ResponseEntity.ok(new LoginResponseDTO(accessToken, headerInfo));
+	}
+}

--- a/src/main/java/com/clover/salad/employee/command/application/controller/AuthController.java
+++ b/src/main/java/com/clover/salad/employee/command/application/controller/AuthController.java
@@ -1,4 +1,4 @@
-package com.clover.salad.security;
+package com.clover.salad.employee.command.application.controller;
 
 import com.clover.salad.employee.command.domain.aggregate.vo.RequestLoginVO;
 import com.clover.salad.employee.command.domain.aggregate.entity.EmployeeEntity;
@@ -6,10 +6,12 @@ import com.clover.salad.employee.command.domain.repository.EmployeeRepository;
 import com.clover.salad.employee.query.dto.LoginHeaderInfoDTO;
 import com.clover.salad.employee.query.dto.LoginResponseDTO;
 import com.clover.salad.employee.query.service.EmployeeQueryService;
+import com.clover.salad.security.JwtUtil;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -27,6 +29,7 @@ public class AuthController {
 	private final EmployeeQueryService employeeQueryService;
 	private final JwtUtil jwtUtil;
 	private final PasswordEncoder passwordEncoder;
+	private final RedisTemplate<String, String> redisTemplate;
 
 	@PostMapping("/login")
 	public ResponseEntity<LoginResponseDTO> login(@RequestBody RequestLoginVO request,
@@ -44,9 +47,17 @@ public class AuthController {
 		UserDetails userDetails = employeeQueryService.loadUserByUsername(employee.getCode());
 		String accessToken = jwtUtil.createAccessToken(userDetails.getUsername(), userDetails.getAuthorities());
 
-		// 3. refreshToken은 HttpOnly 쿠키로 전송
+		// 3. refreshToken 생성 및 Redis 저장
 		String refreshToken = jwtUtil.createRefreshToken(employee.getCode());
 
+		redisTemplate.opsForValue().set(
+			"refresh:" + employee.getCode(),
+			refreshToken,
+			Duration.ofHours(8)
+		);
+		System.out.println("[Redis 저장 완료] key = refresh:" + employee.getCode() + ", value = " + refreshToken);
+
+		// 4. refreshToken은 HttpOnly 쿠키로 전송
 		ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
 			.httpOnly(true)
 			.secure(true)
@@ -56,10 +67,10 @@ public class AuthController {
 			.build();
 		response.addHeader("Set-Cookie", cookie.toString());
 
-		// 4. 사용자 표시 정보 조회 (쿼리 기반)
+		// 5. 사용자 표시 정보 조회
 		LoginHeaderInfoDTO headerInfo = employeeQueryService.getLoginHeaderInfo(employee.getCode());
 
-		// 5. 응답 구성
+		// 6. 응답 구성
 		return ResponseEntity.ok(new LoginResponseDTO(accessToken, headerInfo));
 	}
 }

--- a/src/main/java/com/clover/salad/employee/command/application/controller/EmployeeCommandController.java
+++ b/src/main/java/com/clover/salad/employee/command/application/controller/EmployeeCommandController.java
@@ -70,10 +70,14 @@ public class EmployeeCommandController {
 		// 1. 쿠키에서 refreshToken 추출
 		if (request.getCookies() != null) {
 			for (Cookie cookie : request.getCookies()) {
+				System.out.println("[Cookie] name=" + cookie.getName() + ", value=" + cookie.getValue());
 				if ("refreshToken".equals(cookie.getName())) {
 					refreshToken = cookie.getValue();
+					System.out.println("[추출된 refreshToken] " + refreshToken);
 				}
 			}
+		} else {
+			System.out.println("[쿠키 없음]");
 		}
 
 		if (refreshToken == null) {

--- a/src/main/java/com/clover/salad/employee/query/controller/EmployeeQueryController.java
+++ b/src/main/java/com/clover/salad/employee/query/controller/EmployeeQueryController.java
@@ -5,12 +5,17 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.clover.salad.employee.query.dto.EmployeeQueryDTO;
+import com.clover.salad.employee.query.dto.LoginHeaderInfoDTO;
 import com.clover.salad.employee.query.dto.SearchEmployeeDTO;
 import com.clover.salad.employee.query.service.EmployeeQueryService;
 
@@ -41,5 +46,28 @@ public class EmployeeQueryController {
 
 		return ResponseEntity.ok(employees);
 	}
+
+	@GetMapping("/employee/header")
+	public ResponseEntity<LoginHeaderInfoDTO> getLoginHeaderInfo() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || !authentication.isAuthenticated()) {
+			throw new RuntimeException("인증되지 않은 사용자입니다.");
+		}
+
+		Object principal = authentication.getPrincipal();
+		if (!(principal instanceof UserDetails userDetails)) {
+			throw new RuntimeException("인증 정보가 올바르지 않습니다.");
+		}
+
+		String code = userDetails.getUsername();
+		LoginHeaderInfoDTO dto = employeeQueryService.getLoginHeaderInfo(code);
+
+		System.out.println("[DEBUG] 로그인 사용자 코드: " + code);
+		System.out.println("[DEBUG] 마이페이지 DTO: " + dto);
+
+		return ResponseEntity.ok(dto);
+	}
+
 
 }

--- a/src/main/java/com/clover/salad/employee/query/dto/LoginHeaderInfoDTO.java
+++ b/src/main/java/com/clover/salad/employee/query/dto/LoginHeaderInfoDTO.java
@@ -1,0 +1,4 @@
+package com.clover.salad.employee.query.dto;
+
+public class LoginHeaderInfoDTO {
+}

--- a/src/main/java/com/clover/salad/employee/query/dto/LoginHeaderInfoDTO.java
+++ b/src/main/java/com/clover/salad/employee/query/dto/LoginHeaderInfoDTO.java
@@ -1,4 +1,16 @@
 package com.clover.salad.employee.query.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
 public class LoginHeaderInfoDTO {
+	private String name;
+	private String departmentName;
+	private String profileImagePath; // S3 경로
 }

--- a/src/main/java/com/clover/salad/employee/query/dto/LoginResponseDTO.java
+++ b/src/main/java/com/clover/salad/employee/query/dto/LoginResponseDTO.java
@@ -1,0 +1,4 @@
+package com.clover.salad.employee.query.dto;
+
+public class LoginResponseDTO {
+}

--- a/src/main/java/com/clover/salad/employee/query/dto/LoginResponseDTO.java
+++ b/src/main/java/com/clover/salad/employee/query/dto/LoginResponseDTO.java
@@ -1,4 +1,11 @@
 package com.clover.salad.employee.query.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class LoginResponseDTO {
+	private String accessToken;
+	private LoginHeaderInfoDTO loginHeaderInfo;
 }

--- a/src/main/java/com/clover/salad/employee/query/mapper/EmployeeMapper.java
+++ b/src/main/java/com/clover/salad/employee/query/mapper/EmployeeMapper.java
@@ -3,11 +3,15 @@ package com.clover.salad.employee.query.mapper;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import com.clover.salad.employee.query.dto.EmployeeQueryDTO;
+import com.clover.salad.employee.query.dto.LoginHeaderInfoDTO;
 import com.clover.salad.employee.query.dto.SearchEmployeeDTO;
 
 @Mapper
 public interface EmployeeMapper {
 	List<EmployeeQueryDTO> searchEmployees(SearchEmployeeDTO searchEmployeeDTO);
+
+	LoginHeaderInfoDTO findLoginHeaderInfoByCode(@Param("code") String code);
 }

--- a/src/main/java/com/clover/salad/employee/query/service/EmployeeQueryService.java
+++ b/src/main/java/com/clover/salad/employee/query/service/EmployeeQueryService.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import com.clover.salad.employee.query.dto.EmployeeQueryDTO;
+import com.clover.salad.employee.query.dto.LoginHeaderInfoDTO;
 import com.clover.salad.employee.query.dto.SearchEmployeeDTO;
 
 @Service
@@ -13,4 +14,6 @@ public interface EmployeeQueryService {
 	List<EmployeeQueryDTO> searchEmployees(SearchEmployeeDTO searchDto);
 
 	UserDetails loadUserByUsername(String subject);
+
+	LoginHeaderInfoDTO getLoginHeaderInfo(String code);
 }

--- a/src/main/java/com/clover/salad/employee/query/service/EmployeeQueryServiceImpl.java
+++ b/src/main/java/com/clover/salad/employee/query/service/EmployeeQueryServiceImpl.java
@@ -16,6 +16,7 @@ import com.clover.salad.employee.command.domain.aggregate.entity.EmployeeEntity;
 import com.clover.salad.employee.command.domain.aggregate.enums.EmployeeLevel;
 import com.clover.salad.employee.command.domain.repository.EmployeeRepository;
 import com.clover.salad.employee.query.dto.EmployeeQueryDTO;
+import com.clover.salad.employee.query.dto.LoginHeaderInfoDTO;
 import com.clover.salad.employee.query.dto.SearchEmployeeDTO;
 import com.clover.salad.employee.query.mapper.EmployeeMapper;
 
@@ -52,6 +53,11 @@ public class EmployeeQueryServiceImpl implements EmployeeQueryService {
 			employee.getEncPwd(),
 			getAuthorities(employee)
 		);
+	}
+
+	@Override
+	public LoginHeaderInfoDTO getLoginHeaderInfo(String code) {
+		return employeeMapper.findLoginHeaderInfoByCode(code);
 	}
 
 	private Collection<? extends GrantedAuthority> getAuthorities(EmployeeEntity employee) {

--- a/src/main/java/com/clover/salad/security/JwtUtil.java
+++ b/src/main/java/com/clover/salad/security/JwtUtil.java
@@ -55,8 +55,10 @@ public class JwtUtil {
 	public boolean validateToken(String token) {
 		try {
 			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+			System.out.println("[✅ Token 유효] " + token);
 			return true;
 		} catch (Exception e) {
+			System.out.println("[❌ Token 유효하지 않음] 이유: " + e.getClass().getSimpleName() + " - " + e.getMessage());
 			return false;
 		}
 	}
@@ -73,7 +75,9 @@ public class JwtUtil {
 	}
 
 	public String getUsername(String token) {
-		return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject();
+		String username = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject();
+		System.out.println("[👤 Username from token] " + username);
+		return username;
 	}
 
 	private Claims parseClaims(String token) {
@@ -82,6 +86,8 @@ public class JwtUtil {
 
 	public LocalDateTime getExpiration(String token) {
 		Date expirationDate = parseClaims(token).getExpiration();
-		return Instant.ofEpochMilli(expirationDate.getTime()).atZone(ZoneId.systemDefault()).toLocalDateTime();
+		LocalDateTime expiration = Instant.ofEpochMilli(expirationDate.getTime()).atZone(ZoneId.systemDefault()).toLocalDateTime();
+		System.out.println("[⏳ Token 만료시간] " + expiration);
+		return expiration;
 	}
 }

--- a/src/main/resources/com/clover/salad/employee/query/mapper/EmployeeMapper.xml
+++ b/src/main/resources/com/clover/salad/employee/query/mapper/EmployeeMapper.xml
@@ -80,5 +80,14 @@
             AND d.name LIKE CONCAT('%', #{departmentName}, '%')
         </if>
     </select>
-
+    <select id="findLoginHeaderInfoByCode" resultType="com.clover.salad.employee.query.dto.LoginHeaderInfoDTO">
+        SELECT
+            e.name,
+            d.name AS departmentName,
+            f.path AS profilePath
+        FROM employee e
+                 JOIN department d ON e.department_id = d.id
+                 LEFT JOIN file_upload f ON e.profile = f.id
+        WHERE e.code = #{code}
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌연관된 이슈

> close #162 #163

## 📝작업 내용

> 1. 로그인 성공 시 사용자 헤더 정보를 응답에 포함
> 2. 리프레시 토큰 재발급 관련 버그 수정

### 스크린샷 (선택)

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/05d5a5ef-45b5-4f2d-bd41-ac5c28fb279d" />

<img width="1282" alt="image" src="https://github.com/user-attachments/assets/19d92350-43d9-4a38-b022-32fdbc071d96" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
