### PR TITLE
[Refactor] 토큰의 사원 코드를 사용하는 로직을 사원 id를 사용하도록 변경

### DIFF
--- a/src/main/java/com/clover/salad/goal/command/application/controller/GoalCommandController.java
+++ b/src/main/java/com/clover/salad/goal/command/application/controller/GoalCommandController.java
@@ -1,77 +1,67 @@
-// package com.clover.salad.goal.command.application.controller;
-//
-// import java.util.List;
-//
-// import org.springframework.http.ResponseEntity;
-// import org.springframework.web.bind.annotation.DeleteMapping;
-// import org.springframework.web.bind.annotation.PostMapping;
-// import org.springframework.web.bind.annotation.PutMapping;
-// import org.springframework.web.bind.annotation.RequestBody;
-// import org.springframework.web.bind.annotation.RequestHeader;
-// import org.springframework.web.bind.annotation.RequestMapping;
-// import org.springframework.web.bind.annotation.RestController;
-//
-// import com.clover.salad.goal.command.application.dto.GoalDTO;
-// import com.clover.salad.goal.command.application.service.GoalCommandService;
-// import com.clover.salad.security.JwtUtil;
-//
-// import lombok.RequiredArgsConstructor;
-// import lombok.extern.slf4j.Slf4j;
-//
-// @RestController
-// @RequestMapping("/goal")
-// @Slf4j
-// @RequiredArgsConstructor
-// public class GoalCommandController {
-// 	private final GoalCommandService goalCommandService;
-// 	private final JwtUtil jwtUtil;
-//
-// 	/* 설명. 실적 목표 등록 */
-// 	@PostMapping("/register")
-// 	public ResponseEntity<String> registerGoal(
-// 		@RequestHeader("Authorization") String token,
-// 		@RequestBody List<GoalDTO> goalList
-// 	) {
-// 		String pureToken = token.replace("Bearer ", "");
-// 		// String code = jwtUtil.getUsername(pureToken);
-//
-// 		log.info("Registering goal");
-// 		goalCommandService.registerGoal(goalList, code);
-//
-// 		return ResponseEntity.ok("Goal Registered");
-// 	}
-//
-// 	/* 설명. 실적 목표 수정 */
-// 	@PutMapping("/change")
-// 	public ResponseEntity<String> changeGoal(
-// 		@RequestHeader("Authorization") String token,
-// 		@RequestBody List<GoalDTO> goalList
-// 	) {
-//
-// 		String pureToken = token.replace("Bearer ", "");
-// 		String code = jwtUtil.getUsername(pureToken);
-//
-// 		log.info("Changing goal");
-// 		goalCommandService.changeGoal(goalList, code);
-//
-// 		return ResponseEntity.ok("Goal Changed");
-// 	}
-//
-// 	/* 설명. 실적 목표 삭제
-// 	 *  관리자가 퇴사 등으로 인해 달성할 수 없어진 목표를 삭제하는 기능
-// 	 *  목표를 조회 후 선택해서 삭제
-// 	 * */
-// 	@DeleteMapping("/delete")
-// 	public ResponseEntity<String> deleteGoal(
-// 		@RequestHeader("Authorization") String token,
-// 		@RequestBody List<GoalDTO> goalList
-// 	) {
-// 		String pureToken = token.replace("Bearer ", "");
-// 		String code = jwtUtil.getUsername(pureToken);
-//
-// 		log.info("Deleting goal");
-// 		goalCommandService.deleteGoal(goalList, code);
-//
-// 		return ResponseEntity.ok("Goals Deleted");
-// 	}
-// }
+package com.clover.salad.goal.command.application.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.clover.salad.goal.command.application.dto.GoalDTO;
+import com.clover.salad.goal.command.application.service.GoalCommandService;
+import com.clover.salad.security.SecurityUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/goal")
+@Slf4j
+@RequiredArgsConstructor
+public class GoalCommandController {
+	private final GoalCommandService goalCommandService;
+
+	/* 설명. 실적 목표 등록 */
+	@PostMapping("/register")
+	public ResponseEntity<String> registerGoal(
+		@RequestBody List<GoalDTO> goalList
+	) {
+		int employeeId = SecurityUtil.getEmployeeId();
+
+		log.info("Registering goal");
+		goalCommandService.registerGoal(goalList, employeeId);
+
+		return ResponseEntity.ok("Goal Registered");
+	}
+
+	/* 설명. 실적 목표 수정 */
+	@PutMapping("/change")
+	public ResponseEntity<String> changeGoal(
+		@RequestBody List<GoalDTO> goalList
+	) {
+		int employeeId = SecurityUtil.getEmployeeId();
+
+		log.info("Changing goal");
+		goalCommandService.changeGoal(goalList, employeeId);
+
+		return ResponseEntity.ok("Goal Changed");
+	}
+
+	/* 설명. 실적 목표 삭제
+	 *  관리자가 퇴사 등으로 인해 달성할 수 없어진 목표를 삭제하는 기능
+	 *  목표를 조회 후 선택해서 삭제
+	 *  관리자 권한 필요!
+	 * */
+	@DeleteMapping("/delete")
+	public ResponseEntity<String> deleteGoal(
+		@RequestBody List<GoalDTO> goalList
+	) {
+		log.info("Deleting goal");
+		goalCommandService.deleteGoal(goalList);
+
+		return ResponseEntity.ok("Goals Deleted");
+	}
+}

--- a/src/main/java/com/clover/salad/goal/command/application/service/GoalCommandService.java
+++ b/src/main/java/com/clover/salad/goal/command/application/service/GoalCommandService.java
@@ -5,9 +5,9 @@ import java.util.List;
 import com.clover.salad.goal.command.application.dto.GoalDTO;
 
 public interface GoalCommandService {
-	void registerGoal(List<GoalDTO> goalList, String employeeCode);
+	void registerGoal(List<GoalDTO> goalList, int employeeId);
 	
-	void changeGoal(List<GoalDTO> goalList, String employeeCode);
+	void changeGoal(List<GoalDTO> goalList, int employeeId);
 	
-	void deleteGoal(List<GoalDTO> goalList, String employeeCode);
+	void deleteGoal(List<GoalDTO> goalList);
 }

--- a/src/main/java/com/clover/salad/goal/query/controller/GoalQueryController.java
+++ b/src/main/java/com/clover/salad/goal/query/controller/GoalQueryController.java
@@ -1,57 +1,53 @@
-// package com.clover.salad.goal.query.controller;
-//
-// import java.util.List;
-//
-// import org.springframework.http.ResponseEntity;
-// import org.springframework.web.bind.annotation.GetMapping;
-// import org.springframework.web.bind.annotation.PathVariable;
-// import org.springframework.web.bind.annotation.RequestHeader;
-// import org.springframework.web.bind.annotation.RequestMapping;
-// import org.springframework.web.bind.annotation.RestController;
-//
-// import com.clover.salad.goal.command.application.dto.EmployeeSearchTermDTO;
-// import com.clover.salad.goal.command.application.dto.GoalDTO;
-// import com.clover.salad.goal.command.application.dto.DeptSearchTermDTO;
-// import com.clover.salad.goal.query.service.GoalQueryService;
-// import com.clover.salad.security.JwtUtil;
-//
-// import lombok.RequiredArgsConstructor;
-// import lombok.extern.slf4j.Slf4j;
-//
-// @RestController
-// @RequestMapping("/goal")
-// @Slf4j
-// @RequiredArgsConstructor
-// public class GoalQueryController {
-// 	private final GoalQueryService goalQueryService;
-// 	private final JwtUtil jwtUtil;
-//
-// 	/* 설명. 사원 한 명의 목표 조회
-// 	 *  쿼리스트링 수동 변경에 의한 조회 제한 필요
-// 	 * */
-// 	@GetMapping("/employee")
-// 	public ResponseEntity<List<GoalDTO>> searchGoalByEmployeeId(EmployeeSearchTermDTO searchTerm) {
-// 		return ResponseEntity.ok(goalQueryService.searchGoalByEmployeeId(searchTerm));
-// 	}
-//
-// 	/* 설명. 팀장이 소속된 팀원 모두의 목표 조회
-// 	 *  팀장 권한 설정 필요
-// 	 * */
-// 	@GetMapping("/department")
-// 	public ResponseEntity<List<GoalDTO>> searchGoalByDepartmentId(DeptSearchTermDTO searchTerm) {
-// 		return ResponseEntity.ok(goalQueryService.searchGoalByDepartmentId(searchTerm));
-// 	}
-//
-// 	/* 설명. 실적 목표 수정 버튼 누를 시, 현재 선택된 목표의 연도를 가져와서, 그 해의 목표 조회
-// 	 *  지난 기간에 대한 제한은 프론트에서 구현
-// 	 * */
-// 	@GetMapping("/change/{targetYear}")
-// 	public ResponseEntity<List<GoalDTO>> searchYearGoalByCurrentGoal(
-// 		@RequestHeader("Authorization") String token,
-// 		@PathVariable int targetYear
-// 	) {
-// 		String pureToken = token.replace("Bearer ", "");
-// 		String code = jwtUtil.getUsername(pureToken);
-// 		return ResponseEntity.ok(goalQueryService.searchYearGoalByCurrentGoal(code, targetYear));
-// 	}
-// }
+package com.clover.salad.goal.query.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.clover.salad.goal.command.application.dto.EmployeeSearchTermDTO;
+import com.clover.salad.goal.command.application.dto.GoalDTO;
+import com.clover.salad.goal.command.application.dto.DeptSearchTermDTO;
+import com.clover.salad.goal.query.service.GoalQueryService;
+import com.clover.salad.security.SecurityUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/goal")
+@Slf4j
+@RequiredArgsConstructor
+public class GoalQueryController {
+	private final GoalQueryService goalQueryService;
+	
+	/* 설명. 사원 한 명의 목표 조회
+	 *  쿼리스트링 수동 변경에 의한 조회 제한 필요
+	 * */
+	@GetMapping("/employee")
+	public ResponseEntity<List<GoalDTO>> searchGoalByEmployeeId(EmployeeSearchTermDTO searchTerm) {
+		return ResponseEntity.ok(goalQueryService.searchGoalByEmployeeId(searchTerm));
+	}
+
+	/* 설명. 팀장이 소속된 팀원 모두의 목표 조회
+	 *  팀장 권한 설정 필요
+	 * */
+	@GetMapping("/department")
+	public ResponseEntity<List<GoalDTO>> searchGoalByDepartmentId(DeptSearchTermDTO searchTerm) {
+		return ResponseEntity.ok(goalQueryService.searchGoalByDepartmentId(searchTerm));
+	}
+
+	/* 설명. 실적 목표 수정 버튼 누를 시, 현재 선택된 목표의 연도를 가져와서, 그 해의 목표 조회
+	 *  지난 기간에 대한 제한은 프론트에서 구현
+	 * */
+	@GetMapping("/change/{targetYear}")
+	public ResponseEntity<List<GoalDTO>> searchYearGoalByCurrentGoal(
+		@PathVariable int targetYear
+	) {
+		int employeeId = SecurityUtil.getEmployeeId();
+		return ResponseEntity.ok(goalQueryService.searchYearGoalByCurrentGoal(employeeId, targetYear));
+	}
+}

--- a/src/main/java/com/clover/salad/goal/query/mapper/GoalMapper.java
+++ b/src/main/java/com/clover/salad/goal/query/mapper/GoalMapper.java
@@ -22,7 +22,7 @@ public interface GoalMapper {
 	);
 	
 	List<GoalDTO> selectYearGoalByCurrentGoalTargetDate(
-		@Param("employeeCode") String employeeCode,
+		@Param("employeeId") int employeeId,
 		@Param("targetYear") int targetYear
 	);
 }

--- a/src/main/java/com/clover/salad/goal/query/service/GoalQueryService.java
+++ b/src/main/java/com/clover/salad/goal/query/service/GoalQueryService.java
@@ -14,5 +14,5 @@ public interface GoalQueryService {
 	
 	DefaultGoalDTO searchDefaultGoalByLevelAndTargetYear(String employeeLevel, int targetYear);
 	
-	List<GoalDTO> searchYearGoalByCurrentGoal(String employeeCode, int targetYear);
+	List<GoalDTO> searchYearGoalByCurrentGoal(int employeeId, int targetYear);
 }

--- a/src/main/java/com/clover/salad/goal/query/service/GoalQueryServiceImpl.java
+++ b/src/main/java/com/clover/salad/goal/query/service/GoalQueryServiceImpl.java
@@ -35,7 +35,7 @@ public class GoalQueryServiceImpl implements GoalQueryService {
 	}
 	
 	@Override
-	public List<GoalDTO> searchYearGoalByCurrentGoal(String employeeCode, int targetYear) {
-		return goalMapper.selectYearGoalByCurrentGoalTargetDate(employeeCode, targetYear);
+	public List<GoalDTO> searchYearGoalByCurrentGoal(int employeeId, int targetYear) {
+		return goalMapper.selectYearGoalByCurrentGoalTargetDate(employeeId, targetYear);
 	}
 }

--- a/src/main/resources/com/clover/salad/goal/query/mapper/GoalMapper.xml
+++ b/src/main/resources/com/clover/salad/goal/query/mapper/GoalMapper.xml
@@ -190,9 +190,7 @@
              , EG.TARGET_DATE
              , EG.EMPLOYEE_ID
           FROM EMPLOYEE_GOAL EG
-         WHERE EG.EMPLOYEE_ID = (SELECT E.ID
-                                   FROM EMPLOYEE E
-                                  WHERE E.CODE = #{employeeCode})
+         WHERE EG.EMPLOYEE_ID =  #{employeeId}
            AND EG.TARGET_DATE LIKE CONCAT(#{targetYear}, '%')
          ORDER BY TARGET_DATE
     </select>


### PR DESCRIPTION
## 📌연관된 이슈

close #183 
close #184 

## 📝작업 내용

토큰에서 사원 코드 파싱해서 사용하던 로직을 SecurityUtil의 사원 id 사용하도록 변경
관리자 권한 체크하던 메소드를 추후 WebSecurity에서 권한 체크하도록 권한 체크 코드 삭제