### PR TITLE
[Feat] 매출 등록, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/clover/salad/sales/command/application/controller/SalesCommandController.java
+++ b/src/main/java/com/clover/salad/sales/command/application/controller/SalesCommandController.java
@@ -1,0 +1,50 @@
+package com.clover.salad.sales.command.application.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.clover.salad.sales.command.application.dto.SalesCommandDTO;
+import com.clover.salad.sales.command.application.service.SalesCommandService;
+import com.clover.salad.security.SecurityUtil;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/sales")
+public class SalesCommandController {
+
+	private final SalesCommandService salesCommandService;
+
+	@Autowired
+	public SalesCommandController(SalesCommandService salesCommandService) {
+		this.salesCommandService = salesCommandService;
+	}
+
+	@PostMapping
+	public ResponseEntity<Integer> createSales(@RequestBody SalesCommandDTO salesCommandDTO) {
+		int id = salesCommandService.createSales(salesCommandDTO);
+
+		return ResponseEntity.ok(id);
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<String> deleteSales(@PathVariable Integer id) {
+
+		log.info("현재 사용자 권한: {}", SecurityContextHolder.getContext().getAuthentication().getAuthorities());
+
+		if (!SecurityUtil.hasRole("ROLE_ADMIN")) {
+			return ResponseEntity.status(403).body("관리자만 삭제할 수 있습니다.");
+		}
+
+		salesCommandService.deleteSales(id);
+		return ResponseEntity.noContent().build();	// 204 응답
+	}
+}

--- a/src/main/java/com/clover/salad/sales/command/application/dto/SalesCommandDTO.java
+++ b/src/main/java/com/clover/salad/sales/command/application/dto/SalesCommandDTO.java
@@ -1,0 +1,16 @@
+package com.clover.salad.sales.command.application.dto;
+
+import java.time.LocalDate;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SalesCommandDTO {
+	private LocalDate salesDate;
+	private String department;
+	private String employeeName;
+	private int amount;
+	private int contractId;
+}

--- a/src/main/java/com/clover/salad/sales/command/application/mapper/SalesMapper.java
+++ b/src/main/java/com/clover/salad/sales/command/application/mapper/SalesMapper.java
@@ -1,0 +1,23 @@
+package com.clover.salad.sales.command.application.mapper;
+
+import com.clover.salad.sales.command.application.dto.SalesCommandDTO;
+import com.clover.salad.sales.command.domain.aggregate.entity.SalesEntity;
+
+public class SalesMapper {
+
+	/* 설명.
+	 *  실수로 유틸리티 클래스가 인스턴트가 되는 것을 방지하기 위한 제약
+	* */
+	private SalesMapper() {}
+
+	public static SalesEntity toEntity(SalesCommandDTO salesCommandDTO) {
+		return SalesEntity.builder()
+			.salesDate(salesCommandDTO.getSalesDate())
+			.department(salesCommandDTO.getDepartment())
+			.employeeName(salesCommandDTO.getEmployeeName())
+			.amount(salesCommandDTO.getAmount())
+			.contractId(salesCommandDTO.getContractId())
+			.isDeleted(false)
+			.build();
+	}
+}

--- a/src/main/java/com/clover/salad/sales/command/application/service/SalesCommandService.java
+++ b/src/main/java/com/clover/salad/sales/command/application/service/SalesCommandService.java
@@ -1,0 +1,9 @@
+package com.clover.salad.sales.command.application.service;
+
+import com.clover.salad.sales.command.application.dto.SalesCommandDTO;
+
+public interface SalesCommandService {
+	int createSales(SalesCommandDTO salesCommandDTO);
+
+	void deleteSales(Integer id);
+}

--- a/src/main/java/com/clover/salad/sales/command/application/service/SalesCommandServiceImpl.java
+++ b/src/main/java/com/clover/salad/sales/command/application/service/SalesCommandServiceImpl.java
@@ -1,0 +1,42 @@
+package com.clover.salad.sales.command.application.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+import com.clover.salad.sales.command.application.dto.SalesCommandDTO;
+import com.clover.salad.sales.command.application.mapper.SalesMapper;
+import com.clover.salad.sales.command.domain.aggregate.entity.SalesEntity;
+import com.clover.salad.sales.command.domain.repository.SalesRepository;
+import com.clover.salad.security.SecurityUtil;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class SalesCommandServiceImpl implements SalesCommandService {
+
+	private final SalesRepository salesRepository;
+
+	@Autowired
+	public SalesCommandServiceImpl(SalesRepository salesRepository) {
+		this.salesRepository = salesRepository;
+	}
+
+	@Override
+	public int createSales(SalesCommandDTO salesCommandDTO) {
+		SalesEntity salesEntity = SalesMapper.toEntity(salesCommandDTO);
+		return salesRepository.save(salesEntity).getId();
+	}
+
+	@Override
+	public void deleteSales(Integer id) {
+
+
+		SalesEntity sales = salesRepository.findById(id)
+			.orElseThrow(() -> new RuntimeException("존재하지 않는 매출입니다."));
+
+		sales.delete();
+		salesRepository.save(sales);
+	}
+}

--- a/src/main/java/com/clover/salad/sales/command/domain/aggregate/entity/SalesEntity.java
+++ b/src/main/java/com/clover/salad/sales/command/domain/aggregate/entity/SalesEntity.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Setter
+@Builder
 @Entity
 @Table(name = "sales")
 public class SalesEntity {
@@ -20,7 +20,7 @@ public class SalesEntity {
 	@Column(name = "sales_date")
 	private LocalDate salesDate;
 
-	/* 설명. 3단 조인이 일어아냐하는 비효율을 해소하고자 관계 연결하지 않음 */
+	/* 설명. 3단 조인이 일어아야하는 비효율을 해소하고자 관계 연결하지 않음 */
 	@Column(name = "department")
 	private String department;
 
@@ -35,4 +35,8 @@ public class SalesEntity {
 
 	@Column(name = "contract_id")
 	private int contractId;
+
+	public void delete() {
+		this.isDeleted = true;
+	}
 }

--- a/src/main/java/com/clover/salad/sales/command/domain/repository/SalesRepository.java
+++ b/src/main/java/com/clover/salad/sales/command/domain/repository/SalesRepository.java
@@ -1,0 +1,9 @@
+package com.clover.salad.sales.command.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.clover.salad.sales.command.domain.aggregate.entity.SalesEntity;
+
+public interface SalesRepository extends JpaRepository<SalesEntity, Integer> {
+
+}

--- a/src/main/java/com/clover/salad/security/AuthenticationFilter.java
+++ b/src/main/java/com/clover/salad/security/AuthenticationFilter.java
@@ -46,7 +46,6 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) {
 		try {
 			String body = request.getReader().lines().collect(Collectors.joining());
-			log.info("[AUTH FILTER] Raw request body: {}", body);
 
 			ObjectMapper mapper = new ObjectMapper();
 			RequestLoginVO creds = mapper.readValue(body, RequestLoginVO.class);
@@ -54,7 +53,6 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 			return getAuthenticationManager().authenticate(
 				new UsernamePasswordAuthenticationToken(creds.getCode(), creds.getPassword(), new ArrayList<>()));
 		} catch (IOException e) {
-			log.error("[AUTH FILTER] 바디 파싱 실패", e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -66,8 +64,6 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 		EmployeeDetails user = (EmployeeDetails) authResult.getPrincipal();
 		int id = user.getId();
 		String code = user.getCode();
-
-		log.info("로그인 성공 - ID: {}, CODE: {}", id, code);
 
 		String accessToken = jwtUtil.createAccessToken(id, code, user.getAuthorities());
 		String refreshToken = jwtUtil.createRefreshToken(id, code);
@@ -88,8 +84,6 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 		response.setContentType("application/json;charset=UTF-8");
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.writeValue(response.getWriter(), headerInfo);
-
-		log.info("로그인 성공 - 사용자 정보 응답 완료: {}", headerInfo.getName());
 	}
 
 	@Override

--- a/src/main/java/com/clover/salad/security/JwtFilter.java
+++ b/src/main/java/com/clover/salad/security/JwtFilter.java
@@ -59,6 +59,7 @@ public class JwtFilter extends OncePerRequestFilter {
 		try {
 			// 5. 인증 객체 생성 및 SecurityContext에 저장
 			Authentication authentication = jwtUtil.getAuthentication(token);
+
 			if (authentication == null) {
 				response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증 실패");
 				return;

--- a/src/main/java/com/clover/salad/security/JwtUtil.java
+++ b/src/main/java/com/clover/salad/security/JwtUtil.java
@@ -55,9 +55,6 @@ public class JwtUtil {
 			.map(GrantedAuthority::getAuthority)
 			.collect(Collectors.joining(","));
 
-		log.info("발급 전 권한 목록: {}", authorities);
-		log.info("[AccessToken 발급] ID: {}, CODE: {}, AUTH(문자열): {}", employeeId, code, auth);
-
 		return Jwts.builder()
 			.setSubject("ERP_ACCESS") 				// access 토큰임을 구분하기 위한 subject
 			.claim("employeeId", employeeId) 	// 내부 식별자

--- a/src/main/java/com/clover/salad/security/SecurityUtil.java
+++ b/src/main/java/com/clover/salad/security/SecurityUtil.java
@@ -4,6 +4,7 @@ import com.clover.salad.security.EmployeeDetails;
 import com.clover.salad.security.token.TokenPrincipal;
 
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 public class SecurityUtil {
@@ -22,5 +23,15 @@ public class SecurityUtil {
 		}
 
 		throw new IllegalStateException("지원하지 않는 인증 주체 타입입니다: " + principal.getClass().getSimpleName());
+	}
+
+	public static boolean hasRole(String role) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || authentication.getAuthorities() == null) {
+			return false;
+		}
+		return authentication.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)
+			.anyMatch(auth -> auth.equals(role));
 	}
 }


### PR DESCRIPTION
## 📌연관된 이슈

> close #186 #123 #125 

## 📝작업 내용

> 매출 등록, 삭제 구현
> 삭제 시 소프트 딜리트 처리
> 삭제 시 관리자만 가능하도록 권한 체크
> SecurityUtil에 `hasRole()` 메서드 추가
> 삭제 성공, 실패 시 응답 처리

### 스크린샷 (선택)

1. 매출 등록
<img width="1271" alt="Image" src="https://github.com/user-attachments/assets/39c4e175-4283-4adf-a82c-94acac9fce92" />

2. 매출 삭제
<img width="1282" alt="Image" src="https://github.com/user-attachments/assets/aa72bfda-7946-44ed-a052-62e726bd2342" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
