### PR TITLE
[Feat] 결재 내역 조회 기능 구현

### DIFF
--- a/src/main/java/com/clover/salad/approval/command/domain/aggregate/converter/ApprovalStateConverter.java
+++ b/src/main/java/com/clover/salad/approval/command/domain/aggregate/converter/ApprovalStateConverter.java
@@ -1,0 +1,19 @@
+package com.clover.salad.approval.command.domain.aggregate.converter;
+
+import com.clover.salad.approval.command.domain.aggregate.enums.ApprovalState;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class ApprovalStateConverter implements AttributeConverter<ApprovalState, String> {
+
+	@Override
+	public String convertToDatabaseColumn(ApprovalState attribute) {
+		return attribute != null ? attribute.getLabel() : null;
+	}
+
+	@Override
+	public ApprovalState convertToEntityAttribute(String dbData) {
+		return dbData != null ? ApprovalState.fromLabel(dbData) : null;
+	}
+}

--- a/src/main/java/com/clover/salad/approval/command/domain/aggregate/entity/ApprovalEntity.java
+++ b/src/main/java/com/clover/salad/approval/command/domain/aggregate/entity/ApprovalEntity.java
@@ -1,0 +1,58 @@
+package com.clover.salad.approval.command.domain.aggregate.entity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+@Entity
+@Table(name = "approval")
+public class ApprovalEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private int id;
+
+	@Column(name = "code")
+	private String code;
+
+	@Column(name = "title")
+	private String title;
+
+	@Column(name = "content")
+	private String content;
+
+	@Column(name = "req_date")
+	private LocalDateTime reqDate;
+
+	@Column(name = "arpv_date")
+	private LocalDateTime aprvDate;
+
+	@Column(name = "state")
+	private String state;
+
+	@Column(name = "comment")
+	private String comment;
+
+	@Column(name = "req_id")
+	private int reqId;
+
+	@Column(name = "aprv_id")
+	private int aprvId;
+
+	@Column(name = "contract_id")
+	private int contractId;
+}

--- a/src/main/java/com/clover/salad/approval/command/domain/aggregate/entity/ApprovalEntity.java
+++ b/src/main/java/com/clover/salad/approval/command/domain/aggregate/entity/ApprovalEntity.java
@@ -3,7 +3,11 @@ package com.clover.salad.approval.command.domain.aggregate.entity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import com.clover.salad.approval.command.domain.aggregate.converter.ApprovalStateConverter;
+import com.clover.salad.approval.command.domain.aggregate.enums.ApprovalState;
+
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -42,7 +46,8 @@ public class ApprovalEntity {
 	private LocalDateTime aprvDate;
 
 	@Column(name = "state")
-	private String state;
+	@Convert(converter = ApprovalStateConverter.class)
+	private ApprovalState state;
 
 	@Column(name = "comment")
 	private String comment;

--- a/src/main/java/com/clover/salad/approval/command/domain/aggregate/enums/ApprovalState.java
+++ b/src/main/java/com/clover/salad/approval/command/domain/aggregate/enums/ApprovalState.java
@@ -1,0 +1,24 @@
+package com.clover.salad.approval.command.domain.aggregate.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApprovalState {
+
+	REQUESTED("요청"),
+	APPROVED("승인"),
+	REJECTED("반려");
+
+	private final String label;
+
+	public static ApprovalState fromLabel(String label) {
+		for (ApprovalState state : values()) {
+			if (state.label.equals(label)) {
+				return state;
+			}
+		}
+		throw new IllegalArgumentException("Unknown label: " + label);
+	}
+}

--- a/src/main/java/com/clover/salad/approval/query/controller/ApprovalQueryController.java
+++ b/src/main/java/com/clover/salad/approval/query/controller/ApprovalQueryController.java
@@ -1,0 +1,36 @@
+package com.clover.salad.approval.query.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO;
+import com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO;
+import com.clover.salad.approval.query.service.ApprovalQueryService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/approval")
+public class ApprovalQueryController {
+
+	private final ApprovalQueryService approvalQueryService;
+
+	@Autowired
+	public ApprovalQueryController(ApprovalQueryService approvalQueryService) {
+		this.approvalQueryService = approvalQueryService;
+	}
+
+	@PostMapping("/search")
+	public ResponseEntity<List<ApprovalSearchResponseDTO>> searchApprovals(
+		@RequestBody ApprovalSearchRequestDTO requestDTO) {
+		List<ApprovalSearchResponseDTO> results = approvalQueryService.searchApprovals(requestDTO);
+		return ResponseEntity.ok(results);
+	}
+}

--- a/src/main/java/com/clover/salad/approval/query/dto/ApprovalSearchRequestDTO.java
+++ b/src/main/java/com/clover/salad/approval/query/dto/ApprovalSearchRequestDTO.java
@@ -1,5 +1,7 @@
 package com.clover.salad.approval.query.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -25,6 +27,9 @@ public class ApprovalSearchRequestDTO {
 	private String contractCode;
 
 	// 내부에서 권한 기반으로 설정 (사용자 입력 금지)
+g	@JsonIgnore
 	private Integer reqId;
+
+	@JsonIgnore
 	private Integer aprvId;
 }

--- a/src/main/java/com/clover/salad/approval/query/dto/ApprovalSearchRequestDTO.java
+++ b/src/main/java/com/clover/salad/approval/query/dto/ApprovalSearchRequestDTO.java
@@ -3,8 +3,6 @@ package com.clover.salad.approval.query.dto;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Setter
 public class ApprovalSearchRequestDTO {
@@ -15,7 +13,6 @@ public class ApprovalSearchRequestDTO {
 
 	private String reqDateFrom;
 	private String reqDateTo;
-
 	private String aprvDateFrom;
 	private String aprvDateTo;
 
@@ -24,5 +21,10 @@ public class ApprovalSearchRequestDTO {
 
 	private String reqName;
 	private String aprvName;
+
 	private String contractCode;
+
+	// 내부에서 권한 기반으로 설정 (사용자 입력 금지)
+	private Integer reqId;
+	private Integer aprvId;
 }

--- a/src/main/java/com/clover/salad/approval/query/dto/ApprovalSearchRequestDTO.java
+++ b/src/main/java/com/clover/salad/approval/query/dto/ApprovalSearchRequestDTO.java
@@ -27,7 +27,7 @@ public class ApprovalSearchRequestDTO {
 	private String contractCode;
 
 	// 내부에서 권한 기반으로 설정 (사용자 입력 금지)
-g	@JsonIgnore
+	@JsonIgnore
 	private Integer reqId;
 
 	@JsonIgnore

--- a/src/main/java/com/clover/salad/approval/query/dto/ApprovalSearchRequestDTO.java
+++ b/src/main/java/com/clover/salad/approval/query/dto/ApprovalSearchRequestDTO.java
@@ -1,0 +1,28 @@
+package com.clover.salad.approval.query.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class ApprovalSearchRequestDTO {
+
+	private String code;
+	private String title;
+	private String content;
+
+	private String reqDateFrom;
+	private String reqDateTo;
+
+	private String aprvDateFrom;
+	private String aprvDateTo;
+
+	private String state;
+	private String comment;
+
+	private String reqName;
+	private String aprvName;
+	private String contractCode;
+}

--- a/src/main/java/com/clover/salad/approval/query/dto/ApprovalSearchResponseDTO.java
+++ b/src/main/java/com/clover/salad/approval/query/dto/ApprovalSearchResponseDTO.java
@@ -1,0 +1,24 @@
+package com.clover.salad.approval.query.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ApprovalSearchResponseDTO {
+	private int id;
+	private String code;
+	private String title;
+	private String content;
+	private LocalDateTime reqDate;
+	private LocalDateTime aprvDate;
+	private String state;
+	private String comment;
+	private String reqName;
+	private String aprvName;
+	private String contractCode;
+}

--- a/src/main/java/com/clover/salad/approval/query/mapper/ApprovalMapper.java
+++ b/src/main/java/com/clover/salad/approval/query/mapper/ApprovalMapper.java
@@ -1,0 +1,11 @@
+package com.clover.salad.approval.query.mapper;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO;
+import com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO;
+
+@Mapper
+public interface ApprovalMapper {
+	List<ApprovalSearchResponseDTO> searchApprovals(ApprovalSearchRequestDTO request);
+}

--- a/src/main/java/com/clover/salad/approval/query/mapper/ApprovalMapper.java
+++ b/src/main/java/com/clover/salad/approval/query/mapper/ApprovalMapper.java
@@ -1,11 +1,21 @@
 package com.clover.salad.approval.query.mapper;
 
 import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
+
 import com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO;
 import com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO;
 
 @Mapper
 public interface ApprovalMapper {
+
+	// 관리자
 	List<ApprovalSearchResponseDTO> searchApprovals(ApprovalSearchRequestDTO request);
+
+	// 사원
+	List<ApprovalSearchResponseDTO> searchByRequester(ApprovalSearchRequestDTO request);
+
+	// 팀장
+	List<ApprovalSearchResponseDTO> searchByApprover(ApprovalSearchRequestDTO request);
 }

--- a/src/main/java/com/clover/salad/approval/query/service/ApprovalQueryService.java
+++ b/src/main/java/com/clover/salad/approval/query/service/ApprovalQueryService.java
@@ -1,0 +1,10 @@
+package com.clover.salad.approval.query.service;
+
+import java.util.List;
+
+import com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO;
+import com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO;
+
+public interface ApprovalQueryService {
+	List<ApprovalSearchResponseDTO> searchApprovals(ApprovalSearchRequestDTO request);
+}

--- a/src/main/java/com/clover/salad/approval/query/service/ApprovalQueryServiceImpl.java
+++ b/src/main/java/com/clover/salad/approval/query/service/ApprovalQueryServiceImpl.java
@@ -1,0 +1,29 @@
+package com.clover.salad.approval.query.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO;
+import com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO;
+import com.clover.salad.approval.query.mapper.ApprovalMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class ApprovalQueryServiceImpl implements ApprovalQueryService {
+
+	private final ApprovalMapper approvalMapper;
+
+	@Autowired
+	public ApprovalQueryServiceImpl(ApprovalMapper approvalMapper) {
+		this.approvalMapper = approvalMapper;
+	}
+
+	@Override
+	public List<ApprovalSearchResponseDTO> searchApprovals(ApprovalSearchRequestDTO request) {
+		return approvalMapper.searchApprovals(request);
+	}
+}

--- a/src/main/java/com/clover/salad/approval/query/service/ApprovalQueryServiceImpl.java
+++ b/src/main/java/com/clover/salad/approval/query/service/ApprovalQueryServiceImpl.java
@@ -3,11 +3,14 @@ package com.clover.salad.approval.query.service;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO;
 import com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO;
 import com.clover.salad.approval.query.mapper.ApprovalMapper;
+import com.clover.salad.employee.query.service.EmployeeQueryService;
+import com.clover.salad.security.SecurityUtil;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -16,14 +19,36 @@ import lombok.extern.slf4j.Slf4j;
 public class ApprovalQueryServiceImpl implements ApprovalQueryService {
 
 	private final ApprovalMapper approvalMapper;
+	private final EmployeeQueryService employeeQueryService;
 
 	@Autowired
-	public ApprovalQueryServiceImpl(ApprovalMapper approvalMapper) {
+	public ApprovalQueryServiceImpl(ApprovalMapper approvalMapper,
+		EmployeeQueryService employeeQueryService) {
 		this.approvalMapper = approvalMapper;
+		this.employeeQueryService = employeeQueryService;
 	}
 
 	@Override
 	public List<ApprovalSearchResponseDTO> searchApprovals(ApprovalSearchRequestDTO request) {
-		return approvalMapper.searchApprovals(request);
+		int employeeId = SecurityUtil.getEmployeeId();
+		String employeeName = employeeQueryService.findNameById(employeeId);
+
+		if (SecurityUtil.hasRole("ROLE_ADMIN")) {
+			return approvalMapper.searchApprovals(request);
+		}
+
+		if (SecurityUtil.hasRole("ROLE_MANAGER")) {
+			request.setAprvId(employeeId);
+			request.setAprvName(employeeName);
+			return approvalMapper.searchByApprover(request);
+		}
+
+		if (SecurityUtil.hasRole("ROLE_MEMBER")) {
+			request.setReqId(employeeId);
+			request.setReqName(employeeName);
+			return approvalMapper.searchByRequester(request);
+		}
+
+		throw new AccessDeniedException("유효한 권한이 없습니다.");
 	}
 }

--- a/src/main/java/com/clover/salad/approval/query/service/ApprovalQueryServiceImpl.java
+++ b/src/main/java/com/clover/salad/approval/query/service/ApprovalQueryServiceImpl.java
@@ -31,11 +31,12 @@ public class ApprovalQueryServiceImpl implements ApprovalQueryService {
 	@Override
 	public List<ApprovalSearchResponseDTO> searchApprovals(ApprovalSearchRequestDTO request) {
 		int employeeId = SecurityUtil.getEmployeeId();
-		String employeeName = employeeQueryService.findNameById(employeeId);
 
 		if (SecurityUtil.hasRole("ROLE_ADMIN")) {
 			return approvalMapper.searchApprovals(request);
 		}
+
+		String employeeName = employeeQueryService.findNameById(employeeId);
 
 		if (SecurityUtil.hasRole("ROLE_MANAGER")) {
 			request.setAprvId(employeeId);
@@ -48,7 +49,6 @@ public class ApprovalQueryServiceImpl implements ApprovalQueryService {
 			request.setReqName(employeeName);
 			return approvalMapper.searchByRequester(request);
 		}
-
 		throw new AccessDeniedException("유효한 권한이 없습니다.");
 	}
 }

--- a/src/main/java/com/clover/salad/employee/command/domain/aggregate/entity/EmployeeEntity.java
+++ b/src/main/java/com/clover/salad/employee/command/domain/aggregate/entity/EmployeeEntity.java
@@ -31,23 +31,23 @@ public class EmployeeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private int id;
 
-	@Column(name = "code", nullable = false, unique = true)
+	@Column(name = "code")
 	private String code;
 
-	@Column(name = "password", nullable = false)
+	@Column(name = "password")
 	private String password;
 
-	@Column(nullable = false)
+	@Column(name = "name")
 	private String name;
 
-	@Column(nullable = false)
+	@Column(name = "phone")
 	private String phone;
 
-	@Column(nullable = false)
+	@Column(name = "email")
 	private String email;
 
 	@Convert(converter = EmployeeLevelConverter.class)
-	@Column(nullable = false)
+	@Column(name="level")
 	private EmployeeLevel level;
 
 	@Column(name = "hire_date")
@@ -56,18 +56,18 @@ public class EmployeeEntity {
 	@Column(name = "resign_date")
 	private LocalDate resignDate;
 
-	@Column(name = "is_admin", nullable = false)
+	@Column(name = "is_admin")
 	private boolean isAdmin;
 
-	@Column(name = "is_deleted", nullable = false)
+	@Column(name = "is_deleted")
 	private boolean isDeleted;
 
 	@Column(name = "work_place")
 	private String workPlace;
 
-	@Column(name = "department_id", nullable = false)
+	@Column(name = "department_id")
 	private int departmentId;
 
-	@Column(nullable = false)
+	@Column(name="profile")
 	private int profile;
 }

--- a/src/main/java/com/clover/salad/employee/command/domain/aggregate/entity/EmployeeEntity.java
+++ b/src/main/java/com/clover/salad/employee/command/domain/aggregate/entity/EmployeeEntity.java
@@ -16,7 +16,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.ToString;
 
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/clover/salad/employee/command/domain/repository/EmployeeRepository.java
+++ b/src/main/java/com/clover/salad/employee/command/domain/repository/EmployeeRepository.java
@@ -1,9 +1,12 @@
 package com.clover.salad.employee.command.domain.repository;
 
 import java.util.Optional;
+
+import org.apache.ibatis.annotations.Mapper;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.clover.salad.employee.command.domain.aggregate.entity.EmployeeEntity;
 
+@Mapper
 public interface EmployeeRepository extends JpaRepository<EmployeeEntity, Integer> {
 	Optional<EmployeeEntity> findByCode(String code);
 

--- a/src/main/java/com/clover/salad/employee/command/domain/repository/EmployeeRepository.java
+++ b/src/main/java/com/clover/salad/employee/command/domain/repository/EmployeeRepository.java
@@ -1,9 +1,7 @@
 package com.clover.salad.employee.command.domain.repository;
 
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.clover.salad.employee.command.domain.aggregate.entity.EmployeeEntity;
 
 public interface EmployeeRepository extends JpaRepository<EmployeeEntity, Integer> {

--- a/src/main/java/com/clover/salad/employee/command/domain/repository/EmployeeRepository.java
+++ b/src/main/java/com/clover/salad/employee/command/domain/repository/EmployeeRepository.java
@@ -2,11 +2,10 @@ package com.clover.salad.employee.command.domain.repository;
 
 import java.util.Optional;
 
-import org.apache.ibatis.annotations.Mapper;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import com.clover.salad.employee.command.domain.aggregate.entity.EmployeeEntity;
 
-@Mapper
 public interface EmployeeRepository extends JpaRepository<EmployeeEntity, Integer> {
 	Optional<EmployeeEntity> findByCode(String code);
 

--- a/src/main/java/com/clover/salad/employee/query/mapper/EmployeeMapper.java
+++ b/src/main/java/com/clover/salad/employee/query/mapper/EmployeeMapper.java
@@ -27,4 +27,7 @@ public interface EmployeeMapper {
 
 	// 마이페이지 정보 조회
 	EmployeeMypageQueryDTO selectMyPageInfoById(@Param("id") int id);
+
+	// 사원 이름 조회 추가
+	String findNameById(@Param("id") int id);
 }

--- a/src/main/java/com/clover/salad/employee/query/service/EmployeeQueryService.java
+++ b/src/main/java/com/clover/salad/employee/query/service/EmployeeQueryService.java
@@ -25,4 +25,6 @@ public interface EmployeeQueryService {
 	boolean checkIsAdminById(int id);
 
 	String findCodeById(int id);
+
+	String findNameById(int id);
 }

--- a/src/main/java/com/clover/salad/employee/query/service/EmployeeQueryServiceImpl.java
+++ b/src/main/java/com/clover/salad/employee/query/service/EmployeeQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.clover.salad.employee.query.service;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
@@ -66,6 +67,16 @@ public class EmployeeQueryServiceImpl implements EmployeeQueryService, UserDetai
 		return employeeRepository.findById(id)
 			.map(EmployeeEntity::getCode)
 			.orElseThrow(() -> new RuntimeException("사번 조회 실패: " + id));
+	}
+
+	@Override
+	public String findNameById(int id) {
+		String name = employeeMapper.findNameById(id);
+		if (name == null) {
+			throw new IllegalArgumentException("해당 ID의 사원을 찾을 수 없습니다: " + id);
+		}
+		return name;
+
 	}
 
 	@Override

--- a/src/main/resources/com/clover/salad/approval/query/mapper/ApprovalMapper.xml
+++ b/src/main/resources/com/clover/salad/approval/query/mapper/ApprovalMapper.xml
@@ -16,9 +16,11 @@
         <result property="aprvName" column="aprvName" />
         <result property="contractCode" column="contractCode" />
     </resultMap>
+
+    <!-- 관리자 검색 -->
     <select id="searchApprovals"
             parameterType="com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO"
-            resultType="com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO">
+            resultMap="ApprovalSearchResultMap">
         SELECT
                a.id
              , a.code
@@ -51,7 +53,6 @@
             <if test="reqDateTo != null and reqDateTo != ''">
                 AND a.req_date &lt;= STR_TO_DATE(#{reqDateTo}, '%Y-%m-%d')
             </if>
-
             <if test="aprvDateFrom != null and aprvDateFrom != ''">
                 AND a.aprv_date &gt;= STR_TO_DATE(#{aprvDateFrom}, '%Y-%m-%d')
             </if>
@@ -69,6 +70,128 @@
             </if>
             <if test="aprvName != null and aprvName != ''">
                 AND aprv.name LIKE CONCAT('%', #{aprvName}, '%')
+            </if>
+            <if test="contractCode != null and contractCode != ''">
+                AND c.code LIKE CONCAT('%', #{contractCode}, '%')
+            </if>
+        </where>
+         ORDER BY a.code DESC
+    </select>
+
+    <!-- 2. 사원: 본인이 요청한 결재만, aprvName 검색 가능 -->
+    <select id="searchByRequester"
+            parameterType="com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO"
+            resultMap="ApprovalSearchResultMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.content
+             , a.req_date AS reqDate
+             , a.aprv_date AS aprvDate
+             , a.state
+             , a.comment
+             , req.name AS reqName
+             , aprv.name AS aprvName
+             , c.code AS contractCode
+          FROM approval a
+          LEFT JOIN employee req ON a.req_id = req.id
+          LEFT JOIN employee aprv ON a.aprv_id = aprv.id
+          LEFT JOIN contract c ON a.contract_id = c.id
+        <where>
+            <if test="reqId != null">
+                AND req.id = #{reqId}
+            </if>
+            <if test="code != null and code != ''">
+                AND a.code LIKE CONCAT('%', #{code}, '%')
+            </if>
+            <if test="title != null and title != ''">
+                AND a.title LIKE CONCAT('%', #{title}, '%')
+            </if>
+            <if test="content != null and content != ''">
+                AND a.content LIKE CONCAT('%', #{content}, '%')
+            </if>
+            <if test="reqDateFrom != null and reqDateFrom != ''">
+                AND a.req_date &gt;= STR_TO_DATE(#{reqDateFrom}, '%Y-%m-%d')
+            </if>
+            <if test="reqDateTo != null and reqDateTo != ''">
+                AND a.req_date &lt;= STR_TO_DATE(#{reqDateTo}, '%Y-%m-%d')
+            </if>
+            <if test="aprvDateFrom != null and aprvDateFrom != ''">
+                AND a.aprv_date &gt;= STR_TO_DATE(#{aprvDateFrom}, '%Y-%m-%d')
+            </if>
+            <if test="aprvDateTo != null and aprvDateTo != ''">
+                AND a.aprv_date &lt;= STR_TO_DATE(#{aprvDateTo}, '%Y-%m-%d')
+            </if>
+            <if test="state != null and state != ''">
+                AND a.state = #{state}
+            </if>
+            <if test="comment != null and comment != ''">
+                AND a.comment LIKE CONCAT('%', #{comment}, '%')
+            </if>
+            <if test="aprvName != null and aprvName != ''">
+                AND aprv.name LIKE CONCAT('%', #{aprvName}, '%')
+            </if>
+            <if test="contractCode != null and contractCode != ''">
+                AND c.code LIKE CONCAT('%', #{contractCode}, '%')
+            </if>
+        </where>
+         ORDER BY a.code DESC
+    </select>
+
+    <!-- 3. 팀장: 본인이 승인한 결재만, reqName 검색 가능 -->
+    <select id="searchByApprover"
+            parameterType="com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO"
+            resultMap="ApprovalSearchResultMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.content
+             , a.req_date AS reqDate
+             , a.aprv_date AS aprvDate
+             , a.state
+             , a.comment
+             , req.name AS reqName
+             , aprv.name AS aprvName
+             , c.code AS contractCode
+          FROM approval a
+          LEFT JOIN employee req ON a.req_id = req.id
+          LEFT JOIN employee aprv ON a.aprv_id = aprv.id
+          LEFT JOIN contract c ON a.contract_id = c.id
+        <where>
+            <if test="aprvId != null">
+                AND aprv.id = #{aprvId}
+            </if>
+            <if test="code != null and code != ''">
+                AND a.code LIKE CONCAT('%', #{code}, '%')
+            </if>
+            <if test="title != null and title != ''">
+                AND a.title LIKE CONCAT('%', #{title}, '%')
+            </if>
+            <if test="content != null and content != ''">
+                AND a.content LIKE CONCAT('%', #{content}, '%')
+            </if>
+            <if test="reqDateFrom != null and reqDateFrom != ''">
+                AND a.req_date &gt;= STR_TO_DATE(#{reqDateFrom}, '%Y-%m-%d')
+            </if>
+            <if test="reqDateTo != null and reqDateTo != ''">
+                AND a.req_date &lt;= STR_TO_DATE(#{reqDateTo}, '%Y-%m-%d')
+            </if>
+            <if test="aprvDateFrom != null and aprvDateFrom != ''">
+                AND a.aprv_date &gt;= STR_TO_DATE(#{aprvDateFrom}, '%Y-%m-%d')
+            </if>
+            <if test="aprvDateTo != null and aprvDateTo != ''">
+                AND a.aprv_date &lt;= STR_TO_DATE(#{aprvDateTo}, '%Y-%m-%d')
+            </if>
+            <if test="state != null and state != ''">
+                AND a.state = #{state}
+            </if>
+            <if test="comment != null and comment != ''">
+                AND a.comment LIKE CONCAT('%', #{comment}, '%')
+            </if>
+            <if test="reqName != null and reqName != ''">
+                AND req.name LIKE CONCAT('%', #{reqName}, '%')
             </if>
             <if test="contractCode != null and contractCode != ''">
                 AND c.code LIKE CONCAT('%', #{contractCode}, '%')

--- a/src/main/resources/com/clover/salad/approval/query/mapper/ApprovalMapper.xml
+++ b/src/main/resources/com/clover/salad/approval/query/mapper/ApprovalMapper.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.clover.salad.approval.query.mapper.ApprovalMapper">
+    <resultMap id="ApprovalSearchResultMap" type="com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO">
+        <id property="id" column="id" />
+        <result property="code" column="code" />
+        <result property="title" column="title" />
+        <result property="content" column="content" />
+        <result property="reqDate" column="reqDate" />
+        <result property="aprvDate" column="aprvDate" />
+        <result property="state" column="state" />
+        <result property="comment" column="comment" />
+        <result property="reqName" column="reqName" />
+        <result property="aprvName" column="aprvName" />
+        <result property="contractCode" column="contractCode" />
+    </resultMap>
+    <select id="searchApprovals"
+            parameterType="com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO"
+            resultType="com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.content
+             , a.req_date AS reqDate
+             , a.aprv_date AS aprvDate
+             , a.state
+             , a.comment
+             , req.name AS reqName
+             , aprv.name AS aprvName
+             , c.code AS contractCode
+          FROM approval a
+          LEFT JOIN employee req ON a.req_id = req.id
+          LEFT JOIN employee aprv ON a.aprv_id = aprv.id
+          LEFT JOIN contract c ON a.contract_id = c.id
+        <where>
+            <if test="code != null and code != ''">
+                AND a.code LIKE CONCAT('%', #{code}, '%')
+            </if>
+            <if test="title != null and title != ''">
+                AND a.title LIKE CONCAT('%', #{title}, '%')
+            </if>
+            <if test="content != null and content != ''">
+                AND a.content LIKE CONCAT('%', #{content}, '%')
+            </if>
+            <if test="reqDateFrom != null and reqDateFrom != ''">
+                AND a.req_date &gt;= STR_TO_DATE(#{reqDateFrom}, '%Y-%m-%d')
+            </if>
+            <if test="reqDateTo != null and reqDateTo != ''">
+                AND a.req_date &lt;= STR_TO_DATE(#{reqDateTo}, '%Y-%m-%d')
+            </if>
+
+            <if test="aprvDateFrom != null and aprvDateFrom != ''">
+                AND a.aprv_date &gt;= STR_TO_DATE(#{aprvDateFrom}, '%Y-%m-%d')
+            </if>
+            <if test="aprvDateTo != null and aprvDateTo != ''">
+                AND a.aprv_date &lt;= STR_TO_DATE(#{aprvDateTo}, '%Y-%m-%d')
+            </if>
+            <if test="state != null and state != ''">
+                AND a.state = #{state}
+            </if>
+            <if test="comment != null and comment != ''">
+                AND a.comment LIKE CONCAT('%', #{comment}, '%')
+            </if>
+            <if test="reqName != null and reqName != ''">
+                AND req.name LIKE CONCAT('%', #{reqName}, '%')
+            </if>
+            <if test="aprvName != null and aprvName != ''">
+                AND aprv.name LIKE CONCAT('%', #{aprvName}, '%')
+            </if>
+            <if test="contractCode != null and contractCode != ''">
+                AND c.code LIKE CONCAT('%', #{contractCode}, '%')
+            </if>
+        </where>
+         ORDER BY a.code DESC
+    </select>
+</mapper>

--- a/src/main/resources/com/clover/salad/employee/query/mapper/EmployeeMapper.xml
+++ b/src/main/resources/com/clover/salad/employee/query/mapper/EmployeeMapper.xml
@@ -123,4 +123,10 @@
          WHERE e.id = #{id}
            AND e.is_deleted = false
     </select>
+    <select id="findNameById" parameterType="int" resultType="string">
+        SELECT name
+          FROM employee
+         WHERE id = #{id}
+           AND is_deleted = false
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌연관된 이슈

> close #113 

## 📝작업 내용

> 권한 기반 결재 내역 조회 기능 구현

> 사원과 팀장은 본인의 결재 내역만 조회 및 검색 가능
> 관리자는 전체 결재 내역 조회 및 검색 가능
> 요청, 응답 dto 분리
> 결재 상태 enum을 한글로 db에 저장, 클라이언트에 반환하도록 설계

### 스크린샷 (선택)

1. 사원으로 조회

<img width="1289" alt="Image" src="https://github.com/user-attachments/assets/af1b5ad6-3c28-4c95-b417-2a0fff1f57f3" />

2. 팀장으로 조회

<img width="1291" alt="Image" src="https://github.com/user-attachments/assets/71c63435-27bf-42e7-91fb-3eaf5cdff4ac" />

3. 관리자로 조회

<img width="1299" alt="Image" src="https://github.com/user-attachments/assets/4035c9b4-7476-4f2b-92cb-f4ecf5e5b647" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
