### PR TITLE
[Feat] 결재 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/clover/salad/approval/query/controller/ApprovalQueryController.java
+++ b/src/main/java/com/clover/salad/approval/query/controller/ApprovalQueryController.java
@@ -4,11 +4,14 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.clover.salad.approval.query.dto.ApprovalDetailDTO;
 import com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO;
 import com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO;
 import com.clover.salad.approval.query.service.ApprovalQueryService;
@@ -32,5 +35,11 @@ public class ApprovalQueryController {
 		@RequestBody ApprovalSearchRequestDTO requestDTO) {
 		List<ApprovalSearchResponseDTO> results = approvalQueryService.searchApprovals(requestDTO);
 		return ResponseEntity.ok(results);
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<ApprovalDetailDTO> getApprovalDetail(@PathVariable int id) {
+		ApprovalDetailDTO dto = approvalQueryService.getApprovalDetailById(id);
+		return ResponseEntity.ok(dto);
 	}
 }

--- a/src/main/java/com/clover/salad/approval/query/dto/ApprovalDetailDTO.java
+++ b/src/main/java/com/clover/salad/approval/query/dto/ApprovalDetailDTO.java
@@ -1,0 +1,29 @@
+package com.clover.salad.approval.query.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ApprovalDetailDTO {
+	private int id;
+	private String code;
+	private String title;
+	private String content;
+	private LocalDateTime reqDate;
+	private LocalDateTime aprvDate;
+	private String state; // Enum이 아닌 각 Enum의 한글 Label
+	private String comment;
+	private String reqName;
+	private String aprvName;
+	private String contractCode;
+
+	private Integer reqId;
+	private Integer aprvId;
+}

--- a/src/main/java/com/clover/salad/approval/query/mapper/ApprovalMapper.java
+++ b/src/main/java/com/clover/salad/approval/query/mapper/ApprovalMapper.java
@@ -3,13 +3,16 @@ package com.clover.salad.approval.query.mapper;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
+import com.clover.salad.approval.query.dto.ApprovalDetailDTO;
 import com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO;
 import com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO;
 
 @Mapper
 public interface ApprovalMapper {
 
+	/* 설명. 결재 내역 목록 조회 */
 	// 관리자
 	List<ApprovalSearchResponseDTO> searchApprovals(ApprovalSearchRequestDTO request);
 
@@ -18,4 +21,7 @@ public interface ApprovalMapper {
 
 	// 팀장
 	List<ApprovalSearchResponseDTO> searchByApprover(ApprovalSearchRequestDTO request);
+
+	/* 설명. 결재 내역 상세 조회 */
+	ApprovalDetailDTO findApprovalDetailById(@Param("id") int id);
 }

--- a/src/main/java/com/clover/salad/approval/query/service/ApprovalQueryService.java
+++ b/src/main/java/com/clover/salad/approval/query/service/ApprovalQueryService.java
@@ -2,9 +2,12 @@ package com.clover.salad.approval.query.service;
 
 import java.util.List;
 
+import com.clover.salad.approval.query.dto.ApprovalDetailDTO;
 import com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO;
 import com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO;
 
 public interface ApprovalQueryService {
 	List<ApprovalSearchResponseDTO> searchApprovals(ApprovalSearchRequestDTO request);
+
+	ApprovalDetailDTO getApprovalDetailById(int id);
 }

--- a/src/main/java/com/clover/salad/approval/query/service/ApprovalQueryServiceImpl.java
+++ b/src/main/java/com/clover/salad/approval/query/service/ApprovalQueryServiceImpl.java
@@ -6,12 +6,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
+import com.clover.salad.approval.query.dto.ApprovalDetailDTO;
 import com.clover.salad.approval.query.dto.ApprovalSearchRequestDTO;
 import com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO;
 import com.clover.salad.approval.query.mapper.ApprovalMapper;
 import com.clover.salad.employee.query.service.EmployeeQueryService;
 import com.clover.salad.security.SecurityUtil;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -49,6 +51,38 @@ public class ApprovalQueryServiceImpl implements ApprovalQueryService {
 			request.setReqName(employeeName);
 			return approvalMapper.searchByRequester(request);
 		}
+		throw new AccessDeniedException("유효한 권한이 없습니다.");
+	}
+
+	@Override
+	public ApprovalDetailDTO getApprovalDetailById(int id) {
+		ApprovalDetailDTO dto = approvalMapper.findApprovalDetailById(id);
+
+		if (dto == null) {
+			throw new EntityNotFoundException("해당 결재를 찾을 수 없습니다.");
+		}
+
+		int currentEmployeeId = SecurityUtil.getEmployeeId();
+
+		// 권한별 접근 제어
+		if (SecurityUtil.hasRole("ROLE_ADMIN")) {
+			return dto;
+		}
+
+		if (SecurityUtil.hasRole("ROLE_MANAGER")) {
+			if (!dto.getAprvId().equals(currentEmployeeId)) {
+				throw new AccessDeniedException("팀장은 자신에게 요청된 결재만 조회할 수 있습니다.");
+			}
+			return dto;
+		}
+
+		if (SecurityUtil.hasRole("ROLE_MEMBER")) {
+			if (!dto.getReqId().equals(currentEmployeeId)) {
+				throw new AccessDeniedException("사원은 자신이 요청한 결재만 조회할 수 있습니다.");
+			}
+			return dto;
+		}
+
 		throw new AccessDeniedException("유효한 권한이 없습니다.");
 	}
 }

--- a/src/main/resources/com/clover/salad/approval/query/mapper/ApprovalMapper.xml
+++ b/src/main/resources/com/clover/salad/approval/query/mapper/ApprovalMapper.xml
@@ -3,6 +3,8 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.clover.salad.approval.query.mapper.ApprovalMapper">
+
+    <!--  결재 내역 목록  -->
     <resultMap id="ApprovalSearchResultMap" type="com.clover.salad.approval.query.dto.ApprovalSearchResponseDTO">
         <id property="id" column="id" />
         <result property="code" column="code" />
@@ -15,6 +17,23 @@
         <result property="reqName" column="reqName" />
         <result property="aprvName" column="aprvName" />
         <result property="contractCode" column="contractCode" />
+    </resultMap>
+
+    <!--  결재 상세 정보  -->
+    <resultMap id="ApprovalDetailResultMap" type="com.clover.salad.approval.query.dto.ApprovalDetailDTO">
+        <id property="id" column="id" />
+        <result property="code" column="code" />
+        <result property="title" column="title" />
+        <result property="content" column="content" />
+        <result property="reqDate" column="reqDate" />
+        <result property="aprvDate" column="aprvDate" />
+        <result property="state" column="state" />
+        <result property="comment" column="comment" />
+        <result property="reqName" column="reqName" />
+        <result property="aprvName" column="aprvName" />
+        <result property="contractCode" column="contractCode" />
+        <result property="reqId" column="reqId"/>
+        <result property="aprvId" column="aprvId"/>
     </resultMap>
 
     <!-- 관리자 검색 -->
@@ -198,5 +217,27 @@
             </if>
         </where>
          ORDER BY a.code DESC
+    </select>
+    <select id="findApprovalDetailById" parameterType="int"
+            resultType="com.clover.salad.approval.query.dto.ApprovalDetailDTO">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.content
+             , a.req_date AS reqDate
+             , a.aprv_date AS aprvDate
+             , a.state
+             , a.comment
+             , req.name AS reqName
+             , aprv.name AS aprvName
+             , c.code AS contractCode
+             , a.req_id AS reqId
+             , a.aprv_id AS aprvId
+        FROM approval a
+          LEFT JOIN employee req ON a.req_id = req.id
+          LEFT JOIN employee aprv ON a.aprv_id = aprv.id
+          LEFT JOIN contract c ON a.contract_id = c.id
+         WHERE a.id = #{id}
     </select>
 </mapper>


### PR DESCRIPTION
## 📌연관된 이슈

> close #114 

## 📝작업 내용

> 결재 상세 조회 API(`/approval/{id}`) 구현

- 상세 정보 조회를 위한 `ApprovalDetailDTO` 생성
- MyBatis XML에 `findApprovalDetailById` 쿼리 작성 및 resultMap 구성
- `ApprovalQueryServiceImpl`에서 권한별 접근 제한 로직 추가:
  - ROLE_MEMBER → 본인 요청 건만
  - ROLE_MANAGER → 본인 결재 건만
  - ROLE_ADMIN → 전체 접근 가능

### 스크린샷 (선택)
1. 사원이 권한이 없는 결재를 조회하려고 하는 경우

<img width="1274" alt="Image" src="https://github.com/user-attachments/assets/718de709-96e0-4dea-bf79-89caf49a43b9" />

2. 사원이 권한이 있는 결재를 조회하는 경우

<img width="1294" alt="Image" src="https://github.com/user-attachments/assets/efe55ce4-a0d1-487b-9177-355194cb51d3" />

3. 팀장이 권한이 없는 결재를 조회하려고 하는 경우

<img width="1296" alt="Image" src="https://github.com/user-attachments/assets/19e19558-84bc-40d6-917b-0238bb4df505" />

4. 팀장이 권한이 있는 결재를 조회하는 경우

<img width="1299" alt="Image" src="https://github.com/user-attachments/assets/8aa57ac3-fc6b-4e33-adcd-fc8f9bcc68cb" />

5. 관리자가 조회하는 경우

<img width="1291" alt="Image" src="https://github.com/user-attachments/assets/41c9377b-9198-43f2-a208-03dba7c35c23" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
