### PR TITLE
[Feat] 계약서 양식 등록 구현

### DIFF
--- a/src/main/java/com/clover/salad/common/file/service/LocalFileStorageService.java
+++ b/src/main/java/com/clover/salad/common/file/service/LocalFileStorageService.java
@@ -7,11 +7,13 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.clover.salad.common.file.entity.FileUploadEntity;
 import com.clover.salad.common.file.repository.FileUploadRepository;
 
+@Service
 public class LocalFileStorageService implements FileStorageService {
 
 	@Value("${file.upload.dir}")

--- a/src/main/java/com/clover/salad/documentTemplate/command/application/controller/DocumentTemplateCommandController.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/application/controller/DocumentTemplateCommandController.java
@@ -1,33 +1,39 @@
-// package com.clover.salad.documentTemplate.command.application.controller;
-//
-// import org.springframework.http.ResponseEntity;
-// import org.springframework.web.bind.annotation.PostMapping;
-// import org.springframework.web.bind.annotation.RequestBody;
-// import org.springframework.web.bind.annotation.RequestMapping;
-// import org.springframework.web.bind.annotation.RestController;
-//
-// import com.clover.salad.contract.command.dto.ContractUploadResponseDTO;
-// import com.clover.salad.documentTemplate.command.application.dto.DocumentTemplateUploadRequestDTO;
-// import com.clover.salad.documentTemplate.command.application.dto.DocumentTemplateUploadResponseDTO;
-// import com.clover.salad.documentTemplate.command.application.service.DocumentTemplateCommandService;
-//
-// @RestController
-// @RequestMapping("/api/command/documentTemplate")
-// public class DocumentTemplateCommandController {
-//
-// 	private final DocumentTemplateCommandService documentTemplateCommandService;
-//
-// 	@PostMapping("/upload")
-// 	public ResponseEntity<DocumentTemplateUploadResponseDTO> uploadDocumentTemplate(
-// 		@RequestBody DocumentTemplateUploadRequestDTO documentTemplateUploadRequestDTO) {
-//
-// 		try {
-// 			DocumentTemplateUploadResponseDTO response =
-// 				documentTemplateCommandService.uploadDocumentTemplate(documentTemplateUploadRequestDTO);
-// 			return ResponseEntity.ok(response);
-// 		} catch (Exception e) {
-// 			return ResponseEntity.badRequest().body(
-// 				new DocumentTemplateUploadResponseDTO(null, "템플릿 업로드 실패: " + e.getMessage()));
-// 		}
-// 	}
-// }
+package com.clover.salad.documentTemplate.command.application.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.clover.salad.documentTemplate.command.application.dto.DocumentTemplateUploadRequestDTO;
+import com.clover.salad.documentTemplate.command.application.dto.DocumentTemplateUploadResponseDTO;
+import com.clover.salad.documentTemplate.command.application.service.DocumentTemplateCommandService;
+
+@RestController
+@RequestMapping("/api/command/documentTemplate")
+public class DocumentTemplateCommandController {
+
+	private final DocumentTemplateCommandService documentTemplateCommandService;
+
+	public DocumentTemplateCommandController(DocumentTemplateCommandService documentTemplateCommandService) {
+		this.documentTemplateCommandService = documentTemplateCommandService;
+	}
+
+	@PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<DocumentTemplateUploadResponseDTO> uploadDocumentTemplate(
+		@RequestPart("file") MultipartFile file,
+		@RequestPart("meta") DocumentTemplateUploadRequestDTO documentTemplateUploadRequestDTO) {
+
+		try {
+			DocumentTemplateUploadResponseDTO response =
+				documentTemplateCommandService.uploadDocumentTemplate(file, documentTemplateUploadRequestDTO);
+			return ResponseEntity.ok(response);
+		} catch (Exception e) {
+			return ResponseEntity.badRequest().body(
+				new DocumentTemplateUploadResponseDTO(null, "템플릿 업로드 실패: " + e.getMessage()));
+		}
+	}
+}

--- a/src/main/java/com/clover/salad/documentTemplate/command/application/controller/DocumentTemplateCommandController.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/application/controller/DocumentTemplateCommandController.java
@@ -1,0 +1,14 @@
+// package com.clover.salad.documentTemplate.command.application.controller;
+//
+// import org.springframework.http.ResponseEntity;
+// import org.springframework.web.bind.annotation.PostMapping;
+// import org.springframework.web.bind.annotation.RequestMapping;
+// import org.springframework.web.bind.annotation.RestController;
+//
+// @RestController
+// @RequestMapping("/api/command/documentTemplate")
+// public class DocumentTemplateCommandController {
+//
+// 	@PostMapping("/upload")
+// 	public ResponseEntity<DocumentTemplateUploadResponseDTO> uploadDocumentTemplate(@RequestParam )
+// }

--- a/src/main/java/com/clover/salad/documentTemplate/command/application/controller/DocumentTemplateCommandController.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/application/controller/DocumentTemplateCommandController.java
@@ -2,13 +2,32 @@
 //
 // import org.springframework.http.ResponseEntity;
 // import org.springframework.web.bind.annotation.PostMapping;
+// import org.springframework.web.bind.annotation.RequestBody;
 // import org.springframework.web.bind.annotation.RequestMapping;
 // import org.springframework.web.bind.annotation.RestController;
+//
+// import com.clover.salad.contract.command.dto.ContractUploadResponseDTO;
+// import com.clover.salad.documentTemplate.command.application.dto.DocumentTemplateUploadRequestDTO;
+// import com.clover.salad.documentTemplate.command.application.dto.DocumentTemplateUploadResponseDTO;
+// import com.clover.salad.documentTemplate.command.application.service.DocumentTemplateCommandService;
 //
 // @RestController
 // @RequestMapping("/api/command/documentTemplate")
 // public class DocumentTemplateCommandController {
 //
+// 	private final DocumentTemplateCommandService documentTemplateCommandService;
+//
 // 	@PostMapping("/upload")
-// 	public ResponseEntity<DocumentTemplateUploadResponseDTO> uploadDocumentTemplate(@RequestParam )
+// 	public ResponseEntity<DocumentTemplateUploadResponseDTO> uploadDocumentTemplate(
+// 		@RequestBody DocumentTemplateUploadRequestDTO documentTemplateUploadRequestDTO) {
+//
+// 		try {
+// 			DocumentTemplateUploadResponseDTO response =
+// 				documentTemplateCommandService.uploadDocumentTemplate(documentTemplateUploadRequestDTO);
+// 			return ResponseEntity.ok(response);
+// 		} catch (Exception e) {
+// 			return ResponseEntity.badRequest().body(
+// 				new DocumentTemplateUploadResponseDTO(null, "템플릿 업로드 실패: " + e.getMessage()));
+// 		}
+// 	}
 // }

--- a/src/main/java/com/clover/salad/documentTemplate/command/application/dto/DocumentTemplateUploadRequestDTO.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/application/dto/DocumentTemplateUploadRequestDTO.java
@@ -1,0 +1,4 @@
+package com.clover.salad.documentTemplate.command.application.dto;
+
+public class DocumentTemplateUploadRequestDTO {
+}

--- a/src/main/java/com/clover/salad/documentTemplate/command/application/dto/DocumentTemplateUploadRequestDTO.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/application/dto/DocumentTemplateUploadRequestDTO.java
@@ -1,4 +1,18 @@
 package com.clover.salad.documentTemplate.command.application.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class DocumentTemplateUploadRequestDTO {
+	private String name;
+	private String description;
+	private int fileUploadId;
 }

--- a/src/main/java/com/clover/salad/documentTemplate/command/application/dto/DocumentTemplateUploadResponseDTO.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/application/dto/DocumentTemplateUploadResponseDTO.java
@@ -1,14 +1,13 @@
 package com.clover.salad.documentTemplate.command.application.dto;
 
-import org.springframework.stereotype.Service;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @Getter
-@Service
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString

--- a/src/main/java/com/clover/salad/documentTemplate/command/application/dto/DocumentTemplateUploadResponseDTO.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/application/dto/DocumentTemplateUploadResponseDTO.java
@@ -1,0 +1,4 @@
+package com.clover.salad.documentTemplate.command.application.dto;
+
+public class DocumentTemplateUploadResponseDTO {
+}

--- a/src/main/java/com/clover/salad/documentTemplate/command/application/dto/DocumentTemplateUploadResponseDTO.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/application/dto/DocumentTemplateUploadResponseDTO.java
@@ -1,4 +1,19 @@
 package com.clover.salad.documentTemplate.command.application.dto;
 
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Service
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class DocumentTemplateUploadResponseDTO {
+	private Integer id;
+	private String message;
 }
+

--- a/src/main/java/com/clover/salad/documentTemplate/command/application/service/DocumentTemplateCommandService.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/application/service/DocumentTemplateCommandService.java
@@ -1,12 +1,15 @@
 package com.clover.salad.documentTemplate.command.application.service;
 
-import org.springframework.stereotype.Service;
+import java.io.IOException;
+
+import org.springframework.web.multipart.MultipartFile;
 
 import com.clover.salad.documentTemplate.command.application.dto.DocumentTemplateUploadRequestDTO;
 import com.clover.salad.documentTemplate.command.application.dto.DocumentTemplateUploadResponseDTO;
 
-
 public interface DocumentTemplateCommandService {
 
-	DocumentTemplateUploadResponseDTO uploadDocumentTemplate(DocumentTemplateUploadRequestDTO requestDTO);
+	DocumentTemplateUploadResponseDTO uploadDocumentTemplate(MultipartFile file, DocumentTemplateUploadRequestDTO dto) throws
+		IOException;
+
 }

--- a/src/main/java/com/clover/salad/documentTemplate/command/application/service/DocumentTemplateCommandService.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/application/service/DocumentTemplateCommandService.java
@@ -1,0 +1,12 @@
+package com.clover.salad.documentTemplate.command.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.clover.salad.documentTemplate.command.application.dto.DocumentTemplateUploadRequestDTO;
+import com.clover.salad.documentTemplate.command.application.dto.DocumentTemplateUploadResponseDTO;
+
+
+public interface DocumentTemplateCommandService {
+
+	DocumentTemplateUploadResponseDTO uploadDocumentTemplate(DocumentTemplateUploadRequestDTO requestDTO);
+}

--- a/src/main/java/com/clover/salad/documentTemplate/command/application/service/DocumentTemplateCommandServiceImpl.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/application/service/DocumentTemplateCommandServiceImpl.java
@@ -1,8 +1,44 @@
 package com.clover.salad.documentTemplate.command.application.service;
 
+import java.io.IOException;
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.clover.salad.common.file.entity.FileUploadEntity;
+import com.clover.salad.common.file.service.FileStorageService;
+import com.clover.salad.contract.document.entity.DocumentTemplate;
+import com.clover.salad.documentTemplate.command.application.dto.DocumentTemplateUploadRequestDTO;
+import com.clover.salad.documentTemplate.command.application.dto.DocumentTemplateUploadResponseDTO;
+import com.clover.salad.contract.document.repository.DocumentTemplateRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
 public class DocumentTemplateCommandServiceImpl implements DocumentTemplateCommandService {
 
+	private final DocumentTemplateRepository documentTemplateRepository;
+	private final FileStorageService fileStorageService;
+
+	@Override
+	public DocumentTemplateUploadResponseDTO uploadDocumentTemplate(MultipartFile file,
+		DocumentTemplateUploadRequestDTO dto) throws IOException {
+
+		FileUploadEntity uploaded = fileStorageService.store(file, "계약서");
+
+		DocumentTemplate entity = DocumentTemplate.builder()
+			.name(dto.getName())
+			.description(dto.getDescription())
+			.version("1")
+			.createdAt(LocalDateTime.now())
+			.isDeleted(false)
+			.fileUpload(uploaded)
+			.build();
+
+		DocumentTemplate saved = documentTemplateRepository.save(entity);
+
+		return new DocumentTemplateUploadResponseDTO(saved.getId(), "템플릿 업로드 성공");
+	}
 }

--- a/src/main/java/com/clover/salad/documentTemplate/command/application/service/DocumentTemplateCommandServiceImpl.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/application/service/DocumentTemplateCommandServiceImpl.java
@@ -1,0 +1,8 @@
+package com.clover.salad.documentTemplate.command.application.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class DocumentTemplateCommandServiceImpl implements DocumentTemplateCommandService {
+
+}

--- a/src/main/java/com/clover/salad/documentTemplate/command/domain/aggregate/entity/DocumentTemplateEntity.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/domain/aggregate/entity/DocumentTemplateEntity.java
@@ -1,0 +1,51 @@
+// package com.clover.salad.documentTemplate.command.domain.aggregate.entity;
+//
+// import java.time.LocalDateTime;
+//
+// import com.fasterxml.jackson.annotation.JsonProperty;
+//
+// import jakarta.persistence.Column;
+// import jakarta.persistence.Entity;
+// import jakarta.persistence.GeneratedValue;
+// import jakarta.persistence.GenerationType;
+// import jakarta.persistence.Id;
+// import jakarta.persistence.Table;
+// import lombok.AllArgsConstructor;
+// import lombok.Builder;
+// import lombok.Getter;
+// import lombok.NoArgsConstructor;
+// import lombok.Setter;
+// import lombok.ToString;
+//
+// @Entity
+// @Getter
+// @Setter
+// @NoArgsConstructor
+// @AllArgsConstructor
+// @ToString
+// @Builder
+// @Table(name = "document_template")
+// public class DocumentTemplateEntity {
+// 	@Id
+// 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+// 	private int id;
+//
+// 	@Column(name = "name")
+// 	private String name;
+//
+// 	@Column(name = "version")
+// 	private String version;
+//
+// 	@Column(name = "description")
+// 	private String description;
+//
+// 	@Column(name = "created_at")
+// 	private LocalDateTime createdAt;
+//
+// 	@Column(name = "is_deleted")
+// 	@JsonProperty("is_deleted")
+// 	private boolean isDeleted;
+//
+// 	@Column(name = "file_upload_id")
+// 	private int fileUploadId;
+// }

--- a/src/main/java/com/clover/salad/documentTemplate/command/domain/repository/DocumentTemplateCommandRepository.java
+++ b/src/main/java/com/clover/salad/documentTemplate/command/domain/repository/DocumentTemplateCommandRepository.java
@@ -1,0 +1,10 @@
+package com.clover.salad.documentTemplate.command.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.clover.salad.contract.document.entity.DocumentTemplate;
+
+@Repository
+public interface DocumentTemplateCommandRepository extends JpaRepository<DocumentTemplate, Integer> {
+}


### PR DESCRIPTION
## 📌연관된 이슈

close #102 

## 📝작업 내용

계약서 양식 등록 기능 추가.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/e16f2ddf-c6d3-4672-90ae-528f41120020)

## 💬리뷰 요구사항(선택)

POST http://localhost:8080/api/command/documentTemplate/upload
BODY -> form-data
입력 조건
Key file로 설정 (File)   VALUE에  렌탈계약서_한글 파일 사용하면됨
Key meta로 설정 (TEXT)  VALUE에 {"name":"표준양식","description":"2024 계약서 템플릿"}; 사용

중요 ... 눌러서 Content-Type 활성화해서 application/json 추가해야합니다
파일 + DTO(Json) 형식을 한번에 받아야해서 그럼


