### PR TITLE
[Feat] : AWS S3 버킷 파일 업로드 함수 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 
     /* === [개발 편의] === */
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation platform('software.amazon.awssdk:bom:2.25.15')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:auth'
 }
 
 tasks.named('test') {

--- a/db/SaladERP.sql
+++ b/db/SaladERP.sql
@@ -47,7 +47,7 @@ CREATE TABLE FILE_UPLOAD
     rename_file VARCHAR(512) NOT NULL,
     path        VARCHAR(512) NOT NULL,
     created_at  DATETIME     NOT NULL,
-    type        VARCHAR(3)   NOT NULL,
+    type        VARCHAR(20)   NOT NULL,
     CONSTRAINT PK_FILE_UPLOAD PRIMARY KEY (id)
 );
 

--- a/src/main/java/com/clover/salad/common/file/config/S3Config.java
+++ b/src/main/java/com/clover/salad/common/file/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.clover.salad.common.file.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public S3Client s3Client() {
+		return S3Client.builder()
+			.region(Region.of(region))
+			.credentialsProvider(
+				StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
+			)
+			.build();
+	}
+}

--- a/src/main/java/com/clover/salad/common/file/controller/FileUploadController.java
+++ b/src/main/java/com/clover/salad/common/file/controller/FileUploadController.java
@@ -1,0 +1,47 @@
+package com.clover.salad.common.file.controller;
+
+import com.clover.salad.common.file.dto.FileUploadResultDTO;
+import com.clover.salad.common.file.enums.FileUploadType;
+import com.clover.salad.common.file.service.FileUploadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/command/file")
+@RequiredArgsConstructor
+public class FileUploadController {
+
+	private final FileUploadService fileUploadService;
+
+	/**
+	 * 공통 파일 업로드 엔드포인트
+	 * @param file MultipartFile 객체
+	 * @param type 파일 타입 (CONTRACT, PRODUCT, EMPLOYEE)
+	 * 각 도메인에서 필요한 곳에서 의존성 주입해서 bean화 시켜서
+	 * 사용하면 됩니다.
+	 */
+	@PostMapping("/upload")
+	public ResponseEntity<?> uploadFile(
+		@RequestParam("file") MultipartFile file,
+		@RequestParam("type") FileUploadType type
+	) {
+		try {
+			var entity = fileUploadService.uploadAndSave(file, type);
+			var resultDTO = FileUploadResultDTO.builder()
+				.originFile(entity.getOriginFile())
+				.renamedFile(entity.getRenameFile())
+				.url(entity.getPath())
+				.type(entity.getType())
+				.build();
+
+			return ResponseEntity.ok(resultDTO);
+		} catch (Exception e) {
+			log.error("[파일 업로드 실패]", e);
+			return ResponseEntity.internalServerError().body("파일 업로드 실패: " + e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/clover/salad/common/file/dto/FileUploadResultDTO.java
+++ b/src/main/java/com/clover/salad/common/file/dto/FileUploadResultDTO.java
@@ -1,0 +1,25 @@
+package com.clover.salad.common.file.dto;
+
+import com.clover.salad.common.file.enums.FileUploadType;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FileUploadResultDTO {
+	private String originFile;
+	private String renamedFile;
+	private String url;
+	private FileUploadType type;
+}
+
+
+

--- a/src/main/java/com/clover/salad/common/file/entity/FileUploadEntity.java
+++ b/src/main/java/com/clover/salad/common/file/entity/FileUploadEntity.java
@@ -2,12 +2,17 @@ package com.clover.salad.common.file.entity;
 
 import java.time.LocalDateTime;
 
+import com.clover.salad.common.file.enums.FileUploadType;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,29 +20,38 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "file_upload")
+@Table(name = "FILE_UPLOAD")
 @Getter
 @Setter
-@Builder
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FileUploadEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer id;
 
-	@Column(name = "origin_file")
+	@Column(name = "origin_file", nullable = false, length = 512)
 	private String originFile;
 
-	@Column(name = "rename_file")
+	@Column(name = "rename_file", nullable = false, length = 512)
 	private String renameFile;
 
-	@Column(name = "path")
+	@Column(name = "path", nullable = false, length = 512)
 	private String path;
 
-	@Column(name = "created_at")
+	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
 
-	@Column(name = "type")
-	private String type; // 예: 계약서
+	@Enumerated(EnumType.STRING)
+	@Column(name = "type", nullable = false, length = 10)
+	private FileUploadType type;
+
+	@Builder
+	public FileUploadEntity(String originFile, String renameFile, String path, FileUploadType type) {
+		this.originFile = originFile;
+		this.renameFile = renameFile;
+		this.path = path;
+		this.createdAt = LocalDateTime.now();
+		this.type = type;
+	}
 }

--- a/src/main/java/com/clover/salad/common/file/enums/FileUploadType.java
+++ b/src/main/java/com/clover/salad/common/file/enums/FileUploadType.java
@@ -1,0 +1,17 @@
+package com.clover.salad.common.file.enums;
+
+public enum FileUploadType {
+	CONTRACT("계약서"),
+	PRODUCT("상품"),
+	EMPLOYEE("프로필");
+
+	private final String label;
+
+	FileUploadType(String label) {
+		this.label = label;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+}

--- a/src/main/java/com/clover/salad/common/file/repository/FileUploadRepository.java
+++ b/src/main/java/com/clover/salad/common/file/repository/FileUploadRepository.java
@@ -1,8 +1,10 @@
 package com.clover.salad.common.file.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import com.clover.salad.common.file.entity.FileUploadEntity;
 
+@Repository
 public interface FileUploadRepository extends JpaRepository<FileUploadEntity, Integer> {
 }

--- a/src/main/java/com/clover/salad/common/file/service/FileUploadService.java
+++ b/src/main/java/com/clover/salad/common/file/service/FileUploadService.java
@@ -1,0 +1,44 @@
+package com.clover.salad.common.file.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.clover.salad.common.file.entity.FileUploadEntity;
+import com.clover.salad.common.file.enums.FileUploadType;
+import com.clover.salad.common.file.repository.FileUploadRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FileUploadService {
+
+	private final S3Uploader s3Uploader;
+	private final S3PathResolver pathResolver;
+	private final FileUploadRepository fileUploadRepository;
+
+	public FileUploadEntity uploadAndSave(MultipartFile multipartFile, FileUploadType type) throws IOException {
+		String origin = multipartFile.getOriginalFilename();
+		String renamed = UUID.randomUUID() + "_" + origin;
+		File tempFile = File.createTempFile("upload-", ".tmp");
+		multipartFile.transferTo(tempFile);
+
+		String key = pathResolver.resolve(type, renamed);
+		String url = s3Uploader.upload(tempFile, key);
+
+		FileUploadEntity entity = FileUploadEntity.builder()
+			.originFile(origin)
+			.renameFile(renamed)
+			.path(url)
+			.type(type)
+			.build();
+
+		return fileUploadRepository.save(entity);
+	}
+}

--- a/src/main/java/com/clover/salad/common/file/service/LocalFileStorageService.java
+++ b/src/main/java/com/clover/salad/common/file/service/LocalFileStorageService.java
@@ -3,7 +3,6 @@ package com.clover.salad.common.file.service;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -11,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.clover.salad.common.file.entity.FileUploadEntity;
+import com.clover.salad.common.file.enums.FileUploadType;
 import com.clover.salad.common.file.repository.FileUploadRepository;
 
 @Service
@@ -38,8 +38,7 @@ public class LocalFileStorageService implements FileStorageService {
 			.originFile(file.getOriginalFilename())
 			.renameFile(rename)
 			.path(uploadDir)
-			.createdAt(LocalDateTime.now())
-			.type(type)
+			.type(FileUploadType.valueOf(type))
 			.build();
 
 		return fileUploadRepository.save(upload);

--- a/src/main/java/com/clover/salad/common/file/service/S3PathResolver.java
+++ b/src/main/java/com/clover/salad/common/file/service/S3PathResolver.java
@@ -1,0 +1,21 @@
+package com.clover.salad.common.file.service;
+
+import org.springframework.stereotype.Component;
+
+import com.clover.salad.common.file.enums.FileUploadType;
+
+@Component
+public class S3PathResolver {
+
+	public String resolve(FileUploadType type, String renamedFile) {
+		String prefix;
+		switch (type) {
+			case CONTRACT -> prefix = "contract/";
+			case PRODUCT -> prefix = "product/";
+			case EMPLOYEE -> prefix = "employee/";
+			default -> throw new IllegalArgumentException("Unknown file type");
+		}
+		return prefix + renamedFile;
+	}
+}
+

--- a/src/main/java/com/clover/salad/common/file/service/S3Uploader.java
+++ b/src/main/java/com/clover/salad/common/file/service/S3Uploader.java
@@ -1,0 +1,40 @@
+package com.clover.salad.common.file.service;
+
+import java.io.File;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class S3Uploader {
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	private final S3Client s3Client;
+
+	public String upload(File file, String key) {
+		PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+			.bucket(bucket)
+			.key(key)
+			.build();
+
+		try {
+			s3Client.putObject(putObjectRequest, RequestBody.fromFile(file));
+			return s3Client.utilities().getUrl(GetUrlRequest.builder().bucket(bucket).key(key).build()).toString();
+		} catch (S3Exception e) {
+			log.error("S3 업로드 실패: {}", e.getMessage(), e);
+			throw new RuntimeException("파일 업로드 실패", e);
+		}
+	}
+}

--- a/src/main/java/com/clover/salad/contract/document/service/DocumentOriginService.java
+++ b/src/main/java/com/clover/salad/contract/document/service/DocumentOriginService.java
@@ -1,6 +1,7 @@
 package com.clover.salad.contract.document.service;
 
 import com.clover.salad.common.file.entity.FileUploadEntity;
+import com.clover.salad.common.file.enums.FileUploadType;
 import com.clover.salad.common.file.repository.FileUploadRepository;
 import com.clover.salad.contract.document.entity.DocumentOrigin;
 import com.clover.salad.contract.document.entity.DocumentTemplate;
@@ -55,8 +56,7 @@ public class DocumentOriginService {
 			.originFile(originalFilename)
 			.renameFile(storedFileName)
 			.path(savedFile.getAbsolutePath())
-			.createdAt(LocalDateTime.now())
-			.type("계약서")
+			.type(FileUploadType.valueOf("CONTRACT"))
 			.build());
 
 		// 5. 기본 템플릿 조회


### PR DESCRIPTION
## 📌연관된 이슈

close #260 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 지금 파일업로드 Enum 타입 영어로 해놔서 Varchar3에 터져서 테이블 수정했음
- 기존 로컬 파일 업로드에서 S3로 변환시 각각 도메인 컨트롤러에서 의존성 주입해서 사용하면됨
- 그래들 동기화 한번 하세요
- 테이블 새로 만드셔야합니다
- yml관련 aws설정파일 노션 참고자료에 추가하겠습니다
- 각 도메인에서 사용시 파일 업로드 타입 지정해서 넘겨주셔야합니다     
- S3PathResolver가 반환경로 바꿔줍니다

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/a6b31dca-bca7-43bb-8a85-5da78457fce9)


## 💬리뷰 요구사항(선택)


### 혹시 이거때문에 본인 기능 안된다 하면 말해주세요꼭
### POST http://localhost:8080/api/command/file/upload
#### form-data
Key: file (type: file)
Key: type (value: CONTRACT / PRODUCT / EMPLOYEE)