### PR TITLE
공지사항, 문의사항 등록 시 알림 생성 기능 추가

### DIFF
--- a/db/Dummy.sql
+++ b/db/Dummy.sql
@@ -85,8 +85,8 @@ VALUES ('profile1.png', 'uuid1.png', '/uploads/', '2025-05-28 02:13:22', '프로
 
 -- EMPLOYEE
 -- 관리자 더미
-INSERT INTO employee (id, code, password, name, phone, email, level, hire_date, resign_date, is_admin, is_deleted, work_place, department_id, profile) VALUES
-(-1, 'ADMIN', '$2a$10$eu/cmPGCdI.cJKQHSi12..fq50TgXsJ3UjKg/nB4SC6rvAyK0woWW', '관리자', '01000000000', 'admin@saladerp.com', '관리자', '1000-01-01', NULL, TRUE, FALSE, '관리자', 1, 1);
+INSERT INTO employee (code, password, name, phone, email, level, hire_date, resign_date, is_admin, is_deleted, work_place, department_id, profile) VALUES
+('ADMIN', '$2a$10$eu/cmPGCdI.cJKQHSi12..fq50TgXsJ3UjKg/nB4SC6rvAyK0woWW', '관리자', '01000000000', 'admin@saladerp.com', '관리자', '1000-01-01', NULL, TRUE, FALSE, '관리자', 1, 1);
 
 -- 사원, 팀장 더미
 -- 영업 1팀

--- a/src/main/java/com/clover/salad/employee/query/mapper/EmployeeMapper.java
+++ b/src/main/java/com/clover/salad/employee/query/mapper/EmployeeMapper.java
@@ -19,6 +19,9 @@ public interface EmployeeMapper {
 	// 사원 검색
 	List<EmployeeSearchResponseDTO> searchEmployees(EmployeeSearchRequestDTO requestDTO);
 
+	// 모든 관리자 검색
+	List<Integer> findAdminIds();
+
 	// 비밀번호 재설정 로직 중
 	Integer selectIdByCodeAndEmail(@Param("code") String code, @Param("email") String email);
 

--- a/src/main/resources/com/clover/salad/employee/query/mapper/EmployeeMapper.xml
+++ b/src/main/resources/com/clover/salad/employee/query/mapper/EmployeeMapper.xml
@@ -222,4 +222,13 @@
          WHERE e.id = #{id}
            AND e.is_deleted = FALSE
     </select>
+
+    <!--  관리자 전체 검색  -->
+    <select id="findAdminIds" resultType="int">
+        SELECT
+               id
+          FROM employee
+         WHERE is_deleted = FALSE
+           AND is_admin = TRUE
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌연관된 이슈

> close #264 

## 📝작업 내용

> 공지사항/문의사항 등록 및 답변 시 알림이 수신자에게 전송되도록 기능을 추가

- 공지사항 작성 시 대상자 중 작성자를 제외한 사원에게 알림 전송
- 문의사항 등록 시 관리자 전원에게 알림 전송
- 문의사항에 대한 답변이 등록되면 질문 작성자에게 알림 전송


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
