### PR TITLE
Refactor : 계약관련 전반적인 수정

### DIFF
--- a/src/main/java/com/clover/salad/common/file/enums/FileUploadType.java
+++ b/src/main/java/com/clover/salad/common/file/enums/FileUploadType.java
@@ -3,7 +3,7 @@ package com.clover.salad.common.file.enums;
 public enum FileUploadType {
 	CONTRACT("계약서"),
 	PRODUCT("상품"),
-	EMPLOYEE("프로필");
+	PROFILE("프로필");
 
 	private final String label;
 

--- a/src/main/java/com/clover/salad/common/file/service/S3PathResolver.java
+++ b/src/main/java/com/clover/salad/common/file/service/S3PathResolver.java
@@ -12,7 +12,7 @@ public class S3PathResolver {
 		switch (type) {
 			case CONTRACT -> prefix = "contract/";
 			case PRODUCT -> prefix = "product/";
-			case EMPLOYEE -> prefix = "employee/";
+			case PROFILE -> prefix = "employee/";
 			default -> throw new IllegalArgumentException("Unknown file type");
 		}
 		return prefix + renamedFile;

--- a/src/main/java/com/clover/salad/contract/command/dto/ContractDTO.java
+++ b/src/main/java/com/clover/salad/contract/command/dto/ContractDTO.java
@@ -43,13 +43,9 @@ public class ContractDTO {
 	public ContractEntity toEntityWithDefaults(
 		Customer customer,
 		String contractCode,
-		DocumentOrigin documentOrigin
+		DocumentOrigin documentOrigin,
+		EmployeeEntity employee // 사원 엔티티 주입받음
 	) {
-		// 임시 사원 ID 하드코딩
-		EmployeeEntity dummyEmployee = EmployeeEntity.builder()
-			.id(1) // 실제 DB에 존재하는 사원 ID
-			.build();
-
 		return ContractEntity.builder()
 			.code(contractCode)
 			.createdAt(LocalDateTime.now())
@@ -67,8 +63,9 @@ public class ContractDTO {
 			.etc(null)
 			.documentOrigin(documentOrigin)
 			.customer(customer)
-			.employee(dummyEmployee)
+			.employee(employee) // 로그인한 사원 주입
 			.build();
 	}
+
 
 }

--- a/src/main/java/com/clover/salad/contract/command/entity/ContractEntity.java
+++ b/src/main/java/com/clover/salad/contract/command/entity/ContractEntity.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.clover.salad.contract.common.ContractStatus;
+import com.clover.salad.contract.common.ContractStatusConverter;
 import com.clover.salad.contract.common.RelationshipType;
 import com.clover.salad.contract.document.entity.DocumentOrigin;
 import com.clover.salad.customer.command.domain.aggregate.entity.Customer;
@@ -30,8 +31,8 @@ public class ContractEntity {
 	private LocalDate startDate;
 	private LocalDate endDate;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
+	@Column(name = "status", nullable = false, length = 20)
+	@Convert(converter = ContractStatusConverter.class)
 	private ContractStatus status;
 
 	private int amount;

--- a/src/main/java/com/clover/salad/contract/common/ContractStatus.java
+++ b/src/main/java/com/clover/salad/contract/common/ContractStatus.java
@@ -1,7 +1,30 @@
 package com.clover.salad.contract.common;
 
-public enum ContractStatus {
-	결재전, 반려, 결재중, 계약만료, 중도해지, 계약무효;
+import lombok.Getter;
 
-	public static final ContractStatus DEFAULT = 결재전;
+@Getter
+public enum ContractStatus {
+	PENDING("결재전"),
+	REJECTED("반려"),
+	IN_PROGRESS("결재중"),
+	EXPIRED("계약만료"),
+	TERMINATED("중도해지"),
+	INVALID("계약무효");
+
+	private final String label;
+
+	ContractStatus(String label) {
+		this.label = label;
+	}
+
+	public static final ContractStatus DEFAULT = PENDING;
+
+	public static ContractStatus fromLabel(String label) {
+		for (ContractStatus status : values()) {
+			if (status.label.equals(label)) {
+				return status;
+			}
+		}
+		throw new IllegalArgumentException("Unknown label: " + label);
+	}
 }

--- a/src/main/java/com/clover/salad/contract/common/ContractStatusConverter.java
+++ b/src/main/java/com/clover/salad/contract/common/ContractStatusConverter.java
@@ -1,0 +1,22 @@
+package com.clover.salad.contract.common;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class ContractStatusConverter implements AttributeConverter<ContractStatus, String> {
+
+	@Override
+	public String convertToDatabaseColumn(ContractStatus attribute) {
+		if (attribute == null)
+			return null;
+		return attribute.getLabel(); // 한글로 저장
+	}
+
+	@Override
+	public ContractStatus convertToEntityAttribute(String dbData) {
+		if (dbData == null)
+			return null;
+		return ContractStatus.fromLabel(dbData); // 한글 → enum
+	}
+}

--- a/src/main/java/com/clover/salad/customer/command/application/dto/CustomerCreateRequest.java
+++ b/src/main/java/com/clover/salad/customer/command/application/dto/CustomerCreateRequest.java
@@ -5,6 +5,7 @@ import com.clover.salad.common.validator.ValidEmail;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -15,6 +16,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
+@Builder
 public class CustomerCreateRequest {
 
     @NotBlank(message = "이름은 필수입니다.")

--- a/src/main/java/com/clover/salad/customer/command/application/dto/CustomerUpdateRequest.java
+++ b/src/main/java/com/clover/salad/customer/command/application/dto/CustomerUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.clover.salad.customer.command.application.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -9,6 +10,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
+@Builder
 public class CustomerUpdateRequest {
     private String name;
     private String birthdate;

--- a/src/main/java/com/clover/salad/customer/command/domain/repository/CustomerRepository.java
+++ b/src/main/java/com/clover/salad/customer/command/domain/repository/CustomerRepository.java
@@ -1,9 +1,17 @@
 package com.clover.salad.customer.command.domain.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.clover.salad.customer.command.domain.aggregate.entity.Customer;
 
 public interface CustomerRepository extends JpaRepository<Customer, Integer> {
     boolean existsByEmail(String email);
+
+    // 고성연 Transcational 안에서 도중 사용할 jpa 조회용
+    Optional<Customer> findTopByNameAndBirthdateAndPhoneOrderByRegisterAtDesc(
+        String name, String birthdate, String phone
+    );
+
 }


### PR DESCRIPTION
- 계약 관련 Enum타입 수정
- 계약 등록시 로그인한 id 토큰 파싱하여 1로 하드코딩되어있던 부분 수정
- 계약 등록 시 고객 확인

#266, #267, #268

![image](https://github.com/user-attachments/assets/8234ac9b-f512-4037-be69-27aab043edb3)
여기 고객-command-repo부분에 저거 추가했어요
그리고 DTO두개에 @Bulider 두개 추가
