### PR TITLE
enum 타입 변경에 맞춰 더미 수정 및 사원 프로필 업데이트 기능에 S3 저장 로직 반영해 프로필을 S3에 저장하도록 구현

### DIFF
--- a/db/Dummy.sql
+++ b/db/Dummy.sql
@@ -72,16 +72,16 @@ INSERT INTO department (name, is_deleted, sup_dept_id) VALUES
 
 -- FILE_UPLOAD
 INSERT INTO FILE_UPLOAD (origin_file, rename_file, path, created_at, type)
-VALUES ('profile1.png', 'uuid1.png', '/uploads/', '2025-05-28 02:13:22', '프로필'),
-       ('contract1.png', 'uuid2.png', '/uploads/', '2025-05-28 02:13:22', '계약서'),
-       ('product1.png', 'uuid3.png', '/uploads/', '2025-05-28 02:13:22', '상품')
-     , ('profile2.png', 'uuid4.png', '/uploads/', '2025-05-29 23:34:38', '프로필')
-     , ('contract2.png', 'uuid5.png', '/uploads/', '2025-05-29 23:34:38', '계약서')
-     , ('product2.png', 'uuid6.png', '/uploads/', '2025-05-29 23:34:38', '상품')
-     , ('profile3.png', 'uuid7.png', '/uploads/', '2025-05-29 23:34:38', '프로필')
-     , ('contract3.png', 'uuid8.png', '/uploads/', '2025-05-29 23:34:38', '계약서')
-     , ('product3.png', 'uuid9.png', '/uploads/', '2025-05-29 23:34:38', '상품')
-     , ('profile4.png', 'uuid10.png', '/uploads/', '2025-05-29 23:34:38', '프로필');
+VALUES ('profile1.png', 'uuid1.png', '/uploads/', '2025-05-28 02:13:22', 'PROFILE'),
+       ('contract1.png', 'uuid2.png', '/uploads/', '2025-05-28 02:13:22', 'CONTRACT'),
+       ('product1.png', 'uuid3.png', '/uploads/', '2025-05-28 02:13:22', 'PRODUCT')
+     , ('profile2.png', 'uuid4.png', '/uploads/', '2025-05-29 23:34:38', 'PROFILE')
+     , ('contract2.png', 'uuid5.png', '/uploads/', '2025-05-29 23:34:38', 'CONTRACT')
+     , ('product2.png', 'uuid6.png', '/uploads/', '2025-05-29 23:34:38', 'PRODUCT')
+     , ('profile3.png', 'uuid7.png', '/uploads/', '2025-05-29 23:34:38', 'PROFILE')
+     , ('contract3.png', 'uuid8.png', '/uploads/', '2025-05-29 23:34:38', 'CONTRACT')
+     , ('product3.png', 'uuid9.png', '/uploads/', '2025-05-29 23:34:38', 'PRODUCT')
+     , ('profile4.png', 'uuid10.png', '/uploads/', '2025-05-29 23:34:38', 'PROFILE');
 
 -- EMPLOYEE
 -- 관리자 더미
@@ -593,3 +593,4 @@ SET name = '공기 청정기',
 WHERE id = 2;
 
 COMMIT;
+

--- a/db/SaladERP.sql
+++ b/db/SaladERP.sql
@@ -415,3 +415,12 @@ CREATE TABLE CONTRACT_CHANGE_NOTICE
         FOREIGN KEY (contract_id)
             REFERENCES CONTRACT (id)
 );
+
+-- 프로필
+UPDATE file_upload SET type = 'PROFILE' WHERE type = '프로필';
+
+-- 계약서
+UPDATE file_upload SET type = 'CONTRACT' WHERE type = '계약서';
+
+-- 상품
+UPDATE file_upload SET type = 'PRODUCT' WHERE type = '상품';

--- a/src/main/java/com/clover/salad/common/file/controller/FileUploadController.java
+++ b/src/main/java/com/clover/salad/common/file/controller/FileUploadController.java
@@ -32,6 +32,7 @@ public class FileUploadController {
 		try {
 			var entity = fileUploadService.uploadAndSave(file, type);
 			var resultDTO = FileUploadResultDTO.builder()
+				.id(entity.getId())
 				.originFile(entity.getOriginFile())
 				.renamedFile(entity.getRenameFile())
 				.url(entity.getPath())

--- a/src/main/java/com/clover/salad/common/file/dto/FileUploadResultDTO.java
+++ b/src/main/java/com/clover/salad/common/file/dto/FileUploadResultDTO.java
@@ -15,6 +15,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class FileUploadResultDTO {
+	private Integer id;
 	private String originFile;
 	private String renamedFile;
 	private String url;

--- a/src/main/java/com/clover/salad/employee/command/application/controller/EmployeeCommandController.java
+++ b/src/main/java/com/clover/salad/employee/command/application/controller/EmployeeCommandController.java
@@ -56,4 +56,11 @@ public class EmployeeCommandController {
 		employeeCommandService.confirmResetPassword(dto.getToken(), dto.getNewPassword());
 		return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
 	}
+
+	@PatchMapping("/mypage/profile")
+	public ResponseEntity<String> updateProfile(@RequestBody UpdateProfileFileDTO updateProfileFileDTO) {
+		int employeeId = SecurityUtil.getEmployeeId();
+		employeeCommandService.updateProfile(employeeId, updateProfileFileDTO.getFileId());
+		return ResponseEntity.ok("프로필이 성공적으로 변경되었습니다.");
+	}
 }

--- a/src/main/java/com/clover/salad/employee/command/application/dto/UpdateProfileFileDTO.java
+++ b/src/main/java/com/clover/salad/employee/command/application/dto/UpdateProfileFileDTO.java
@@ -1,0 +1,10 @@
+package com.clover.salad.employee.command.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UpdateProfileFileDTO {
+	private final int fileId;
+}

--- a/src/main/java/com/clover/salad/employee/command/application/service/EmployeeCommandService.java
+++ b/src/main/java/com/clover/salad/employee/command/application/service/EmployeeCommandService.java
@@ -14,4 +14,6 @@ public interface EmployeeCommandService {
 	void changePassword(int id, RequestChangePasswordDTO dto);
 
 	void updateProfilePath(int id, String newPath);
+
+	void updateProfile(int employeeId, int fileId);
 }

--- a/src/main/java/com/clover/salad/employee/command/application/service/EmployeeCommandServiceImpl.java
+++ b/src/main/java/com/clover/salad/employee/command/application/service/EmployeeCommandServiceImpl.java
@@ -23,6 +23,7 @@ import com.clover.salad.employee.command.application.dto.EmployeeUpdateDTO;
 import com.clover.salad.employee.command.application.dto.RequestChangePasswordDTO;
 import com.clover.salad.employee.command.domain.aggregate.entity.EmployeeEntity;
 import com.clover.salad.employee.command.domain.repository.EmployeeRepository;
+import com.clover.salad.employee.query.dto.EmployeeQueryDTO;
 import com.clover.salad.employee.query.mapper.EmployeeMapper;
 
 import jakarta.mail.internet.MimeMessage;
@@ -163,5 +164,15 @@ public class EmployeeCommandServiceImpl implements EmployeeCommandService {
 
 		file.setPath(newPath);
 		fileUploadRepository.save(file);
+	}
+
+	@Override
+	@Transactional
+	public void updateProfile(int employeeId, int fileId) {
+		EmployeeEntity employee = employeeRepository.findById(employeeId)
+			.orElseThrow(() -> new RuntimeException("해당 ID의 사원을 찾을 수 없습니다."));
+
+		employee.setProfile(fileId);
+		employeeRepository.save(employee);
 	}
 }

--- a/src/main/java/com/clover/salad/employee/query/mapper/EmployeeMapper.java
+++ b/src/main/java/com/clover/salad/employee/query/mapper/EmployeeMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import com.clover.salad.employee.command.domain.aggregate.entity.EmployeeEntity;
 import com.clover.salad.employee.query.dto.DepartmentEmployeeSearchResponseDTO;
 import com.clover.salad.employee.query.dto.EmployeeDetailDTO;
 import com.clover.salad.employee.query.dto.EmployeeMypageQueryDTO;

--- a/src/main/resources/com/clover/salad/employee/query/mapper/EmployeeMapper.xml
+++ b/src/main/resources/com/clover/salad/employee/query/mapper/EmployeeMapper.xml
@@ -231,4 +231,13 @@
          WHERE is_deleted = FALSE
            AND is_admin = TRUE
     </select>
+
+    <!--  프로필 업로드  -->
+    <update id="updateProfileById">
+        UPDATE
+               EMPLOYEE
+           SET profile = #{fileId}
+         WHERE id = #{employeeId}
+           AND is_deleted = false
+    </update>
 </mapper>


### PR DESCRIPTION
## 📌연관된 이슈

> close #271 

## 📝작업 내용

> 
- 더미데이터의 타입 문자열 값을 enum에 맞게 일괄 수정 (계약서 → CONTRACT, 상품 -> PRODUCT, 프로필 -> PROFILE)
- 프로필 이미지 업로드 시, S3에 저장된 파일의 URL과 ID를 DB에 저장
- 프론트에서 프로필 저장을 누르면 업로드된 파일의 ID를 이용해 사용자 프로필이 갱신됨

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
