### PR TITLE
[Feat] 결재 연동 계약 상태 동기화 및 SSE 알림 누락 방지 개선

### DIFF
--- a/src/main/java/com/clover/salad/approval/command/application/controller/ApprovalCommandController.java
+++ b/src/main/java/com/clover/salad/approval/command/application/controller/ApprovalCommandController.java
@@ -25,7 +25,7 @@ public class ApprovalCommandController {
 	@PostMapping("/request")
 	public ResponseEntity<String> requestApproval(@RequestBody ApprovalRequestDTO dto) {
 		int approvalId = approvalCommandService.requestApproval(dto);
-		String code = approvalCommandService.getApprovalCodeById(approvalId); // 이 메서드를 추가해야 함
+		String code = approvalCommandService.getApprovalCodeById(approvalId);
 		String message = "결재 요청이 정상적으로 처리되었습니다. 결재코드: " + code;
 		return ResponseEntity.ok(message);
 	}

--- a/src/main/java/com/clover/salad/approval/command/application/dto/ApprovalDecisionDTO.java
+++ b/src/main/java/com/clover/salad/approval/command/application/dto/ApprovalDecisionDTO.java
@@ -7,6 +7,6 @@ import lombok.Setter;
 @Setter
 public class ApprovalDecisionDTO {
 	private int approvalId;
-	private String decision;	// 요청에 대한 결재 상태: 승인(APPROVE), 반려(REJECT)
-	private String comment;		// 반려일 경우 필수
+	private String decision;
+	private String comment;
 }

--- a/src/main/java/com/clover/salad/approval/command/application/service/ApprovalCommandServiceImpl.java
+++ b/src/main/java/com/clover/salad/approval/command/application/service/ApprovalCommandServiceImpl.java
@@ -10,7 +10,6 @@ import com.clover.salad.approval.query.mapper.ApprovalMapper;
 import com.clover.salad.contract.command.entity.ContractEntity;
 import com.clover.salad.contract.command.repository.ContractRepository;
 import com.clover.salad.contract.common.ContractStatus;
-import com.clover.salad.contract.query.mapper.ContractMapper;
 import com.clover.salad.employee.query.mapper.EmployeeMapper;
 import com.clover.salad.notification.command.application.dto.NotificationCreateDTO;
 import com.clover.salad.notification.command.application.service.NotificationCommandService;
@@ -26,7 +25,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Slf4j
 @Service
@@ -36,7 +34,6 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
 	private final EmployeeMapper employeeMapper;
 	private final ApprovalMapper approvalMapper;
 	private final NotificationCommandService notificationCommandService;
-	private final ContractMapper contractMapper;
 	private final ContractRepository contractRepository;
 
 	@Autowired
@@ -44,14 +41,12 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
 		EmployeeMapper employeeMapper,
 		ApprovalMapper approvalMapper,
 		NotificationCommandService notificationCommandService,
-		ContractMapper contractMapper,
 		ContractRepository contractRepository
 	) {
 		this.approvalRepository = approvalRepository;
 		this.employeeMapper = employeeMapper;
 		this.approvalMapper = approvalMapper;
 		this.notificationCommandService = notificationCommandService;
-		this.contractMapper = contractMapper;
 		this.contractRepository = contractRepository;
 	}
 
@@ -134,20 +129,20 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
 	/* 설명. 결재 코드 작성 */
 	private String generateCode() {
 		LocalDate now = LocalDate.now();
-		String yearMonth = String.format("%02d%02d", now.getYear() % 100, now.getMonthValue()); // 2501
+		String yearMonth = String.format("%02d%02d", now.getYear() % 100, now.getMonthValue());
 		String prefix = "A-" + yearMonth; // A-2501
 
 		for (int attempt = 0; attempt < 5; attempt++) {
-			String lastCode = approvalMapper.findLastCodeByPrefix(prefix); // e.g., A-2501-0003
+			String lastCode = approvalMapper.findLastCodeByPrefix(prefix);
 
 			int nextSeq = 1;
 
-			if (lastCode != null && lastCode.length() == 11) { // "A-2501-0003" = 11글자
-				String lastSeqStr = lastCode.substring(8); // "0003"
+			if (lastCode != null && lastCode.length() == 11) {
+				String lastSeqStr = lastCode.substring(8);
 				nextSeq = Integer.parseInt(lastSeqStr) + 1;
 			}
 
-			String newCode = String.format("%s-%04d", prefix, nextSeq); // "A-2501-0004"
+			String newCode = String.format("%s-%04d", prefix, nextSeq);
 
 			if (approvalMapper.countByCode(newCode) == 0) {
 				return newCode;

--- a/src/main/java/com/clover/salad/approval/command/domain/repository/ApprovalRepository.java
+++ b/src/main/java/com/clover/salad/approval/command/domain/repository/ApprovalRepository.java
@@ -1,11 +1,8 @@
 package com.clover.salad.approval.command.domain.repository;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.clover.salad.approval.command.domain.aggregate.entity.ApprovalEntity;
-import com.clover.salad.approval.command.domain.aggregate.enums.ApprovalState;
+
 
 public interface ApprovalRepository extends JpaRepository<ApprovalEntity, Integer> {
-	boolean existsByReqIdAndContractIdAndStateIn(int requesterId, int contractId, List<ApprovalState> requested);
 }

--- a/src/main/java/com/clover/salad/approval/query/dto/ApprovalDetailDTO.java
+++ b/src/main/java/com/clover/salad/approval/query/dto/ApprovalDetailDTO.java
@@ -18,7 +18,7 @@ public class ApprovalDetailDTO {
 	private String content;
 	private LocalDateTime reqDate;
 	private LocalDateTime aprvDate;
-	private String state; // Enum이 아닌 각 Enum의 한글 Label
+	private String state;
 	private String comment;
 	private String reqName;
 	private String aprvName;

--- a/src/main/java/com/clover/salad/contract/command/entity/ContractEntity.java
+++ b/src/main/java/com/clover/salad/contract/command/entity/ContractEntity.java
@@ -66,4 +66,8 @@ public class ContractEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "employee_id", nullable = false)
 	private EmployeeEntity employee;
+
+	public void changeStatus(ContractStatus status) {
+		this.status = status;
+	}
 }

--- a/src/main/java/com/clover/salad/contract/common/ContractStatus.java
+++ b/src/main/java/com/clover/salad/contract/common/ContractStatus.java
@@ -7,6 +7,7 @@ public enum ContractStatus {
 	PENDING("결재전"),
 	REJECTED("반려"),
 	IN_PROGRESS("결재중"),
+	IN_CONTRACT("계약중"),
 	EXPIRED("계약만료"),
 	TERMINATED("중도해지"),
 	INVALID("계약무효");

--- a/src/main/java/com/clover/salad/employee/command/application/service/EmployeeCommandServiceImpl.java
+++ b/src/main/java/com/clover/salad/employee/command/application/service/EmployeeCommandServiceImpl.java
@@ -155,8 +155,7 @@ public class EmployeeCommandServiceImpl implements EmployeeCommandService {
 		EmployeeEntity employee = employeeRepository.findById(id)
 			.orElseThrow(() -> new RuntimeException("해당 ID의 사원을 찾을 수 없습니다."));
 
-		Integer profileId = employee.getProfile();
-		if (profileId == null) throw new RuntimeException("등록된 프로필이 없습니다.");
+		int profileId = employee.getProfile();
 
 		FileUploadEntity file = fileUploadRepository.findById(profileId)
 			.orElseThrow(() -> new RuntimeException("해당 프로필 파일을 찾을 수 없습니다."));

--- a/src/main/java/com/clover/salad/employee/query/controller/DepartmentQueryController.java
+++ b/src/main/java/com/clover/salad/employee/query/controller/DepartmentQueryController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.clover.salad.employee.query.dto.DepartmentEmployeeSearchResponseDTO;
 import com.clover.salad.employee.query.dto.DepartmentHierarchyDTO;
-import com.clover.salad.employee.query.dto.EmployeeDetailDTO;
 import com.clover.salad.employee.query.service.DepartmentQueryService;
 import com.clover.salad.employee.query.service.EmployeeQueryService;
 

--- a/src/main/java/com/clover/salad/employee/query/controller/EmployeeQueryController.java
+++ b/src/main/java/com/clover/salad/employee/query/controller/EmployeeQueryController.java
@@ -14,11 +14,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.clover.salad.employee.query.dto.EmployeeDetailDTO;
 import com.clover.salad.employee.query.dto.EmployeeMypageQueryDTO;
-import com.clover.salad.employee.query.dto.EmployeeQueryDTO;
 import com.clover.salad.employee.query.dto.EmployeeSearchRequestDTO;
 import com.clover.salad.employee.query.dto.EmployeeSearchResponseDTO;
 import com.clover.salad.employee.query.dto.LoginHeaderInfoDTO;
-import com.clover.salad.employee.query.dto.SearchEmployeeDTO;
 import com.clover.salad.employee.query.service.EmployeeQueryService;
 import com.clover.salad.security.SecurityUtil;
 

--- a/src/main/java/com/clover/salad/employee/query/service/EmployeeQueryService.java
+++ b/src/main/java/com/clover/salad/employee/query/service/EmployeeQueryService.java
@@ -8,11 +8,9 @@ import org.springframework.stereotype.Service;
 import com.clover.salad.employee.query.dto.DepartmentEmployeeSearchResponseDTO;
 import com.clover.salad.employee.query.dto.EmployeeDetailDTO;
 import com.clover.salad.employee.query.dto.EmployeeMypageQueryDTO;
-import com.clover.salad.employee.query.dto.EmployeeQueryDTO;
 import com.clover.salad.employee.query.dto.EmployeeSearchRequestDTO;
 import com.clover.salad.employee.query.dto.EmployeeSearchResponseDTO;
 import com.clover.salad.employee.query.dto.LoginHeaderInfoDTO;
-import com.clover.salad.employee.query.dto.SearchEmployeeDTO;
 
 @Service
 public interface EmployeeQueryService {
@@ -26,7 +24,7 @@ public interface EmployeeQueryService {
 	EmployeeMypageQueryDTO getMyPageInfoById(int id);
 
 	// boolean checkIsAdmin(String code);
-	boolean checkIsAdminById(int id);
+	// boolean checkIsAdminById(int id);
 
 	String findCodeById(int id);
 

--- a/src/main/java/com/clover/salad/employee/query/service/EmployeeQueryServiceImpl.java
+++ b/src/main/java/com/clover/salad/employee/query/service/EmployeeQueryServiceImpl.java
@@ -66,13 +66,13 @@ public class EmployeeQueryServiceImpl implements EmployeeQueryService, UserDetai
 		return employeeMapper.searchEmployees(requestDTO);
 	}
 
-	@Override
-	public boolean checkIsAdminById(int id) {
-		EmployeeEntity employee = employeeRepository.findById(id)
-			.orElseThrow(() -> new RuntimeException("해당 ID를 가진 사용자를 찾을 수 없습니다."));
-
-		return employee.isAdmin();
-	}
+	// @Override
+	// public boolean checkIsAdminById(int id) {
+	// 	EmployeeEntity employee = employeeRepository.findById(id)
+	// 		.orElseThrow(() -> new RuntimeException("해당 ID를 가진 사용자를 찾을 수 없습니다."));
+	//
+	// 	return employee.isAdmin();
+	// }
 
 	@Override
 	public String findCodeById(int id) {

--- a/src/main/java/com/clover/salad/notification/query/sse/SseEmitterManager.java
+++ b/src/main/java/com/clover/salad/notification/query/sse/SseEmitterManager.java
@@ -1,8 +1,10 @@
 package com.clover.salad.notification.query.sse;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -13,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class SseEmitterManager {
 	private final Map<Integer, SseEmitter> emitters = new ConcurrentHashMap<>();
+	private final Map<Integer, List<Object>> pending = new ConcurrentHashMap<>();
 
 	public SseEmitter connect(int employeeId) {
 		log.info("[SSE] Emitter 등록 시작 - employeeId: {}", employeeId);
@@ -33,6 +36,19 @@ public class SseEmitterManager {
 			log.error("[SSE] 에러 발생 - employeeId: {}, 오류: {}", employeeId, e.getMessage());
 		});
 
+		// 보관된 알림 전송 시도
+		List<Object> buffered = pending.remove(employeeId);
+		if (buffered != null && !buffered.isEmpty()) {
+			for (Object data : buffered) {
+				try {
+					emitter.send(SseEmitter.event().name("notification").data(data));
+					log.info("[SSE] 보관된 알림 전송 - employeeId: {}", employeeId);
+				} catch (IOException e) {
+					log.error("[SSE] 보관된 알림 전송 실패 - {}", e.getMessage());
+				}
+			}
+		}
+
 		return emitter;
 	}
 
@@ -49,8 +65,8 @@ public class SseEmitterManager {
 				log.error("[SSE] 알림 전송 실패 - employeeId: {}, 이유: {}", employeeId, e.getMessage());
 			}
 		} else {
-			log.warn("[SSE] 전송 실패 - employeeId={}의 emitter가 존재하지 않음", employeeId);
+			log.warn("[SSE] emitter 없음 → 알림 보관 - employeeId: {}", employeeId);
+			pending.computeIfAbsent(employeeId, k -> new CopyOnWriteArrayList<>()).add(data);
 		}
 	}
 }
-


### PR DESCRIPTION
## 📌연관된 이슈

> close #274
> close #275 

## 📝작업 내용

### 1. 계약 상태 동기화

- 결재 요청 시: 계약 상태를 `PENDING` → `IN_PROGRESS`로 변경
- 결재 승인 시: 계약 상태를 `IN_PROGRESS` → `IN_CONTRACT`로 변경

### 2. SSE 알림 누락 방지

- emitter가 없을 경우 알림을 pending 큐에 저장
- 사용자가 SSE 재연결 시 큐에 있는 알림을 전송

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
