### PR TITLE
[Feat] 상담 내역 수정

### DIFF
--- a/src/main/java/com/clover/salad/common/validator/EmailValidator.java
+++ b/src/main/java/com/clover/salad/common/validator/EmailValidator.java
@@ -11,7 +11,7 @@ public class EmailValidator implements ConstraintValidator<ValidEmail, String> {
     @Override
     public boolean isValid(String email, ConstraintValidatorContext context) {
         if (email == null || email.isBlank()) {
-            return false;
+            return true;
         }
         return email.matches(EMAIL_REGEX);
     }

--- a/src/main/java/com/clover/salad/consult/command/application/controller/ConsultationCommandController.java
+++ b/src/main/java/com/clover/salad/consult/command/application/controller/ConsultationCommandController.java
@@ -1,12 +1,15 @@
 package com.clover.salad.consult.command.application.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.clover.salad.consult.command.application.dto.ConsultationCreateRequest;
+import com.clover.salad.consult.command.application.dto.ConsultationUpdateRequest;
 import com.clover.salad.consult.command.application.service.ConsultationCommandService;
 
 import jakarta.validation.Valid;
@@ -25,6 +28,14 @@ public class ConsultationCommandController {
 
         consultationCommandService.createConsultation(request);
         return ResponseEntity.ok("상담이 성공적으로 등록되었습니다.");
+    }
+
+    @PatchMapping("/{consultId}")
+    public ResponseEntity<String> updateConsultation(@PathVariable int consultId,
+            @RequestBody @Valid ConsultationUpdateRequest request) {
+
+        consultationCommandService.updateConsultation(consultId, request);
+        return ResponseEntity.ok("상담이 성공적으로 수정되었습니다.");
     }
 
 }

--- a/src/main/java/com/clover/salad/consult/command/application/dto/ConsultationUpdateRequest.java
+++ b/src/main/java/com/clover/salad/consult/command/application/dto/ConsultationUpdateRequest.java
@@ -1,0 +1,37 @@
+package com.clover.salad.consult.command.application.dto;
+
+import com.clover.salad.common.validator.ValidBirthdate;
+import com.clover.salad.common.validator.ValidEmail;
+import com.clover.salad.common.validator.ValidPhone;
+import com.clover.salad.customer.command.domain.aggregate.vo.CustomerType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ConsultationUpdateRequest {
+
+    private String customerName;
+
+    @ValidBirthdate
+    private String customerBirthdate;
+
+    @ValidPhone
+    private String customerPhone;
+
+    @ValidEmail
+    private String customerEmail;
+
+    private String customerAddress;
+
+    @JsonProperty("type")
+    private CustomerType customerType;
+
+    private String customerEtc;
+
+    @NotBlank(message = "상담 내용은 필수입니다.")
+    private String content;
+
+    private String etc;
+
+}

--- a/src/main/java/com/clover/salad/consult/command/application/service/ConsultationCommandService.java
+++ b/src/main/java/com/clover/salad/consult/command/application/service/ConsultationCommandService.java
@@ -1,7 +1,10 @@
 package com.clover.salad.consult.command.application.service;
 
 import com.clover.salad.consult.command.application.dto.ConsultationCreateRequest;
+import com.clover.salad.consult.command.application.dto.ConsultationUpdateRequest;
 
 public interface ConsultationCommandService {
     void createConsultation(ConsultationCreateRequest request);
+
+    void updateConsultation(int consultId, ConsultationUpdateRequest request);
 }

--- a/src/main/java/com/clover/salad/consult/command/application/service/ConsultationCommandServiceImpl.java
+++ b/src/main/java/com/clover/salad/consult/command/application/service/ConsultationCommandServiceImpl.java
@@ -7,10 +7,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.clover.salad.common.util.AuthUtil;
 import com.clover.salad.consult.command.application.dto.ConsultationCreateRequest;
+import com.clover.salad.consult.command.application.dto.ConsultationUpdateRequest;
 import com.clover.salad.consult.command.domain.aggregate.entity.Consultation;
 import com.clover.salad.consult.command.domain.repository.ConsultationRepository;
 import com.clover.salad.customer.command.application.dto.CustomerCreateRequest;
 import com.clover.salad.customer.command.application.service.CustomerCommandService;
+import com.clover.salad.customer.command.domain.aggregate.entity.Customer;
+import com.clover.salad.customer.command.domain.repository.CustomerRepository;
 import com.clover.salad.security.JwtUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,7 @@ public class ConsultationCommandServiceImpl implements ConsultationCommandServic
 
     private final ConsultationRepository consultationRepository;
     private final CustomerCommandService customerCommandService;
+    private final CustomerRepository customerRepository;
     private final JwtUtil jwtUtil;
 
     @Override
@@ -52,6 +56,28 @@ public class ConsultationCommandServiceImpl implements ConsultationCommandServic
                 .etc(request.getEtc()).employeeId(employeeId).customerId(customerId).build();
 
         consultationRepository.save(consultation);
+    }
+
+    @Override
+    @Transactional
+    public void updateConsultation(int consultId, ConsultationUpdateRequest request) {
+        // 1. 상담 엔티티 조회 (삭제되지 않은 상담)
+        Consultation consultation = consultationRepository.findByIdAndIsDeletedFalse(consultId)
+                .orElseThrow(() -> new IllegalArgumentException("삭제되었거나 존재하지 않는 상담입니다."));
+
+        // 2. 고객 엔티티 조회
+        Customer customer = customerRepository.findById(consultation.getCustomerId())
+                .orElseThrow(() -> new IllegalArgumentException("상담에 연결된 고객 정보를 찾을 수 없습니다."));
+
+        // 3. 상담 업데이트 (입력값이 있고, 기존 값과 다를 경우만)
+        consultation.update(
+                Consultation.builder().content(request.getContent()).etc(request.getEtc()).build());
+
+        // 4. 고객 업데이트
+        customer.update(Customer.builder().name(request.getCustomerName())
+                .birthdate(request.getCustomerBirthdate()).phone(request.getCustomerPhone())
+                .email(request.getCustomerEmail()).address(request.getCustomerAddress())
+                .type(request.getCustomerType()).etc(request.getCustomerEtc()).build());
     }
 
     private boolean isBlank(String value) {

--- a/src/main/java/com/clover/salad/consult/command/domain/aggregate/entity/Consultation.java
+++ b/src/main/java/com/clover/salad/consult/command/domain/aggregate/entity/Consultation.java
@@ -61,4 +61,13 @@ public class Consultation {
         this.customerId = customerId;
         this.isDeleted = false;
     }
+
+    public void update(Consultation updated) {
+        if (updated.content != null && !updated.content.equals(this.content)) {
+            this.content = updated.content;
+        }
+        if (updated.etc != null && !updated.etc.equals(this.etc)) {
+            this.etc = updated.etc;
+        }
+    }
 }

--- a/src/main/java/com/clover/salad/consult/command/domain/repository/ConsultationRepository.java
+++ b/src/main/java/com/clover/salad/consult/command/domain/repository/ConsultationRepository.java
@@ -1,8 +1,11 @@
 package com.clover.salad.consult.command.domain.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.clover.salad.consult.command.domain.aggregate.entity.Consultation;
 
 public interface ConsultationRepository extends JpaRepository<Consultation, Integer> {
+
+    Optional<Consultation> findByIdAndIsDeletedFalse(int consultId);
 }

--- a/src/main/java/com/clover/salad/customer/command/application/dto/CustomerUpdateRequest.java
+++ b/src/main/java/com/clover/salad/customer/command/application/dto/CustomerUpdateRequest.java
@@ -5,7 +5,7 @@ import com.clover.salad.common.validator.ValidEmail;
 import com.clover.salad.common.validator.ValidPhone;
 import com.clover.salad.customer.command.domain.aggregate.entity.Customer;
 import com.clover.salad.customer.command.domain.aggregate.vo.CustomerType;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,13 +32,15 @@ public class CustomerUpdateRequest {
     @ValidEmail(message = "유효하지 않은 이메일 형식입니다.")
     private String email;
 
+    @JsonProperty("type")
     private CustomerType type;
 
     private String etc;
 
     /** 부분 수정용 엔티티 변환 */
     public Customer toEntity(CustomerType resolvedType) {
-        return Customer.builder().name(name).birthdate(birthdate).phone(phone).address(address)
+        return Customer.builder().name(name).birthdate(birthdate)
+                .phone(phone != null ? phone.replaceAll("-", "") : null).address(address)
                 .email(email).type(resolvedType).etc(etc).build();
     }
 }

--- a/src/main/java/com/clover/salad/customer/command/application/service/CustomerCommandServiceImpl.java
+++ b/src/main/java/com/clover/salad/customer/command/application/service/CustomerCommandServiceImpl.java
@@ -95,7 +95,7 @@ public class CustomerCommandServiceImpl implements CustomerCommandService {
 		Customer customer = customerRepository.findById(customerId).orElseThrow(
 				() -> new CustomersException.CustomerNotFoundException("고객이 존재하지 않습니다."));
 
-		Customer updated = request.toEntity(customer.getType());
+		Customer updated = request.toEntity(request.getType());
 		customer.update(updated);
 
 		log.info("[고객 수정] ID: {}, 이름: {}", customerId, customer.getName());

--- a/src/main/java/com/clover/salad/customer/command/domain/aggregate/entity/Customer.java
+++ b/src/main/java/com/clover/salad/customer/command/domain/aggregate/entity/Customer.java
@@ -77,16 +77,23 @@ public class Customer {
 
 	/** 변경된 값이 있을 경우만 업데이트 */
 	public void update(Customer updated) {
+		if (this.name == null && updated.name == null) {
+			throw new InvalidCustomerDataException("이름은 필수입니다.");
+		}
 		if (this.phone == null && updated.phone == null) {
 			throw new InvalidCustomerDataException("연락처는 필수입니다.");
 		}
 
 		this.name = updated.name != null ? updated.name : this.name;
 		this.birthdate = updated.birthdate != null ? updated.birthdate : this.birthdate;
-		this.phone = updated.phone != null ? updated.phone : this.phone;
+		this.phone = updated.phone != null ? sanitizePhone(updated.phone) : this.phone;
 		this.address = updated.address != null ? updated.address : this.address;
 		this.email = updated.email != null ? updated.email : this.email;
-		this.type = updated.type != null ? updated.type : this.type;
+
+		if (updated.type != null && !updated.type.equals(this.type)) {
+			this.type = updated.type;
+		}
+
 		this.etc = updated.etc != null ? updated.etc : this.etc;
 	}
 
@@ -102,5 +109,9 @@ public class Customer {
 		if (request.getEtc() != null) {
 			this.etc = request.getEtc();
 		}
+	}
+
+	private String sanitizePhone(String phone) {
+		return phone != null ? phone.replaceAll("-", "") : null;
 	}
 }

--- a/src/main/java/com/clover/salad/customer/command/domain/aggregate/vo/CustomerType.java
+++ b/src/main/java/com/clover/salad/customer/command/domain/aggregate/vo/CustomerType.java
@@ -1,7 +1,6 @@
 package com.clover.salad.customer.command.domain.aggregate.vo;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum CustomerType {
 
@@ -13,12 +12,11 @@ public enum CustomerType {
 		this.label = label;
 	}
 
-	@JsonValue
 	public String getLabel() {
 		return label;
 	}
 
-	@JsonCreator
+	@JsonCreator(mode = JsonCreator.Mode.DELEGATING)
 	public static CustomerType from(String input) {
 		for (CustomerType type : values()) {
 			if (type.getLabel().equals(input)) {

--- a/src/main/java/com/clover/salad/customer/query/dto/CustomerQueryDTO.java
+++ b/src/main/java/com/clover/salad/customer/query/dto/CustomerQueryDTO.java
@@ -37,4 +37,20 @@ public class CustomerQueryDTO {
     private CustomerType type;
 
     private String etc;
+
+    public String getPhone() {
+        return formatPhone(this.phone);
+    }
+
+    private String formatPhone(String raw) {
+        if (raw == null)
+            return null;
+        String digits = raw.replaceAll("\\D", "");
+        if (digits.length() == 10) {
+            return digits.replaceFirst("(\\d{3})(\\d{3})(\\d{4})", "$1-$2-$3");
+        } else if (digits.length() == 11) {
+            return digits.replaceFirst("(\\d{3})(\\d{4})(\\d{4})", "$1-$2-$3");
+        }
+        return raw;
+    }
 }


### PR DESCRIPTION
## 📌연관된 이슈

close #56 

## 📝작업 내용

- 상담 내역 수정
  - 상담 내역이 수정될 때 고객 정보도 수정되면 같이 수정됨
  - PATCH {{baseURL}}/api/consult/{consultId}
  ```json
  {
    // "customerName": "이새롬"
    "customerBirthdate": "1997-03-07"
    , "customerPhone": "010-4321-5678"
    , "type": "리드"
    , "content": "렌탈 상품에 대한 상담 요청입니다. 수정 테스트. 3"
    // , "etc": "프로미스나인 멤버"
  }

## 💬리뷰 요구사항(선택)
- 권한에 따른 분기 처리는 되어 있지 않으니 기능 확인 시 양해 부탁드립니다.