### PR TITLE
[Hotfix] 결재 요청 시 계약 상태 변경 로직 중 누락 부분 추가

### DIFF
--- a/src/main/java/com/clover/salad/approval/command/application/service/ApprovalCommandServiceImpl.java
+++ b/src/main/java/com/clover/salad/approval/command/application/service/ApprovalCommandServiceImpl.java
@@ -57,6 +57,7 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
 		ContractEntity contract = contractRepository.findById(dto.getContractId())
 			.orElseThrow(() -> new IllegalArgumentException("계약이 존재하지 않습니다. 계약 ID: " + dto.getContractId()));
 		contract.changeStatus(ContractStatus.IN_PROGRESS);
+		contractRepository.save(contract);
 		log.info("계약의 상태가 '결재중'으로 변경되었습니다.");
 
 		/* 설명. 팀장은 결재 요청 불가능 */


### PR DESCRIPTION
## 📌연관된 이슈

> close #281 

## 📝작업 내용

> 결재 요청시 계약 상태가 결재전 -> 결재중 으로 바뀌지 않는 문제 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
