### PR TITLE
[Refactor] 상품 상세 조회 기능 개선

### DIFF
--- a/db/Dummy.sql
+++ b/db/Dummy.sql
@@ -72,10 +72,14 @@ VALUES
 ('계약검토팀', FALSE, 10);
 
 -- FILE_UPLOAD
-INSERT INTO FILE_UPLOAD (origin_file, rename_file, path, thumbnail_path, created_at, type)
-VALUES ('profile.png', 'e637698b-fb33-4e96-9dd9-b5602572c50d_profile.png',
+INSERT INTO FILE_UPLOAD (id, origin_file, rename_file, path, thumbnail_path, created_at, type)
+VALUES (1, 'profile.png', 'e637698b-fb33-4e96-9dd9-b5602572c50d_profile.png',
         'https://saladerp-bucket.s3.ap-northeast-2.amazonaws.com/employee/e637698b-fb33-4e96-9dd9-b5602572c50d_profile.png',
-        null, '2025-06-22 23:37', 'PROFILE');
+        null, '2025-06-22 23:37', 'PROFILE'),
+       (2, 'free-icon-electric-appliance-7290460.png',
+        '57a4dba9-b4ce-425d-87fa-6410de334236_free-icon-electric-appliance-7290460.png',
+        'https://saladerp-bucket.s3.ap-northeast-2.amazonaws.com/product/57a4dba9-b4ce-425d-87fa-6410de334236_free-icon-electric-appliance-7290460.png',
+        null, '2025-06-25 11:48:37', 'PRODUCT');
 
 -- EMPLOYEE
 -- 관리자 더미
@@ -506,33 +510,26 @@ VALUES
 -- PRODUCT
 INSERT INTO product (category, name, serial_number, product_code, company, origin_cost, rental_cost, description,
                      is_deleted, file_upload_id)
-VALUES ('냉장고', '오브제컬렉션', 'S834BB30', 'LG-REF-S834BB30', 'LG', 2300000, 43900, 'LG에서 만든 예쁜 냉장고', FALSE, 1)
-     , ('TV', '2024 QLED 4K QDE1 (189 cm) + 3.1 ch 사운드바 B650D', 'KQ75QDE1-B6', 'SAM-TV-KQ75QDE1-B6', '삼성', 3369000,
-        67425, '삼성 QLED TV', FALSE, 1)
-     , ('세탁기', '비스포크 그랑데 AI 세탁기', 'WF24B7600KW', 'SAM-WASH-WF24B7600KW', '삼성', 1890000, 37900, 'AI 기능을 탑재한 삼성 세탁기',
-        FALSE, 2)
+VALUES ('냉장고', '오브제컬렉션', 'S834BB30', 'LG-REF-S834BB30', 'LG', 2300000, 43900, 'LG에서 만든 예쁜 냉장고', FALSE, 2)
+     , ('TV', '2024 QLED 4K QDE1 (189 cm) + 3.1 ch 사운드바 B650D', 'KQ75QDE1-B6', 'SAM-TV-KQ75QDE1-B6', '삼성', 3369000, 67425, '삼성 QLED TV', FALSE, 2)
+     , ('세탁기', '비스포크 그랑데 AI 세탁기', 'WF24B7600KW', 'SAM-WASH-WF24B7600KW', '삼성', 1890000, 37900, 'AI 기능을 탑재한 삼성 세탁기', FALSE, 2)
      , ('건조기', 'LG 트롬 듀얼 인버터 히트펌프', 'RH18VNA', 'LG-DRY-RH18VNA', 'LG', 1720000, 35500, '에너지 효율이 뛰어난 LG 건조기', FALSE, 2)
-     , ('에어컨', '휘센 듀얼 에어컨 2in1', 'FQ18DADWE2', 'LG-AC-FQ18DADWE2', 'LG', 2490000, 46800, '여름 필수품, LG 휘센 에어컨', FALSE, 3)
-     , ('청소기', '제트 무선 청소기 VS20A956B', 'VS20A956B', 'SAM-VAC-VS20A956B', '삼성', 1340000, 27900, '강력한 흡입력의 삼성 무선 청소기',
-        FALSE, 3)
-     , ('오븐', '비스포크 큐커 AI 오븐', 'MC32A7035KT', 'SAM-OVEN-MC32A7035KT', '삼성', 590000, 12500, '다기능 삼성 오븐', FALSE, 4)
-     , ('식기세척기', '디오스 식기세척기 스팀', 'DUBJ1G', 'LG-DISH-DUBJ1G', 'LG', 1380000, 28900, '고온 스팀 살균 LG 식기세척기', FALSE, 4)
-     , ('냉장고', '비스포크 냉장고 4도어', 'RF85T9111AP', 'SAM-REF-RF85T9111AP', '삼성', 3100000, 58900, '고급형 삼성 냉장고', FALSE, 5)
-     , ('TV', 'LG OLED evo C3 65인치', 'OLED65C3KNA', 'LG-TV-OLED65C3KNA', 'LG', 2790000, 55300, '고화질 LG OLED TV', FALSE,
-        5)
-     , ('세탁기', 'LG 트윈워시 세탁기', 'F21VDP', 'LG-WASH-F21VDP', 'LG', 1980000, 39200, '세탁과 탈수를 동시에 LG 트윈워시', FALSE, 6)
-     , ('건조기', '삼성 AI 건조기', 'DV90T8240SH', 'SAM-DRY-DV90T8240SH', '삼성', 1790000, 36500, 'AI 제어 삼성 건조기', FALSE, 6)
-     , ('에어컨', '무풍에어컨 클래식', 'AF17A6474TZ', 'SAM-AC-AF17A6474TZ', '삼성', 2650000, 49500, '무풍 냉방 삼성 에어컨', FALSE, 7)
-     , ('청소기', '코드제로 A9S', 'A958VA', 'LG-VAC-A958VA', 'LG', 1190000, 24500, 'LG 코드제로 무선 청소기', FALSE, 7)
-     , ('오븐', 'LG 광파오븐 MA324B', 'MA324B', 'LG-OVEN-MA324B', 'LG', 540000, 11900, '간편한 요리를 위한 LG 오븐', FALSE, 8)
-     , ('식기세척기', '삼성 비스포크 식기세척기', 'DW60A8055UG', 'SAM-DISH-DW60A8055UG', '삼성', 1450000, 29900, '스마트 기능 탑재 식기세척기', FALSE,
-        8)
-     , ('공기청정기', 'LG 퓨리케어 360° 공기청정기', 'AS351NNFA', 'LG-AP-AS351NNFA', 'LG', 1040000, 20900, '360도 청정 기능 LG 공기청정기',
-        FALSE, 9)
-     , ('공기청정기', '삼성 블루스카이 5000', 'AX60A5510WDD', 'SAM-AP-AX60A5510WDD', '삼성', 980000, 19900, '초미세먼지 제거 삼성 공기청정기',
-        FALSE, 9)
-     , ('전자레인지', 'LG 전자레인지 MW25S', 'MW25S', 'LG-MIW-MW25S', 'LG', 210000, 4900, '간단 요리를 위한 전자레인지', FALSE, 10)
-     , ('제습기', '삼성 무풍 제습기', 'AY10R5171', 'SAM-DEH-AY10R5171', '삼성', 670000, 13900, '쾌적한 여름을 위한 삼성 제습기', FALSE, 10);
+     , ('에어컨', '휘센 듀얼 에어컨 2in1', 'FQ18DADWE2', 'LG-AC-FQ18DADWE2', 'LG', 2490000, 46800, '여름 필수품, LG 휘센 에어컨', FALSE, 2)
+     , ('청소기', '제트 무선 청소기 VS20A956B', 'VS20A956B', 'SAM-VAC-VS20A956B', '삼성', 1340000, 27900, '강력한 흡입력의 삼성 무선 청소기', FALSE, 2)
+     , ('오븐', '비스포크 큐커 AI 오븐', 'MC32A7035KT', 'SAM-OVEN-MC32A7035KT', '삼성', 590000, 12500, '다기능 삼성 오븐', FALSE, 2)
+     , ('식기세척기', '디오스 식기세척기 스팀', 'DUBJ1G', 'LG-DISH-DUBJ1G', 'LG', 1380000, 28900, '고온 스팀 살균 LG 식기세척기', FALSE, 2)
+     , ('냉장고', '비스포크 냉장고 4도어', 'RF85T9111AP', 'SAM-REF-RF85T9111AP', '삼성', 3100000, 58900, '고급형 삼성 냉장고', FALSE, 2)
+     , ('TV', 'LG OLED evo C3 65인치', 'OLED65C3KNA', 'LG-TV-OLED65C3KNA', 'LG', 2790000, 55300, '고화질 LG OLED TV', FALSE, 2)
+     , ('세탁기', 'LG 트윈워시 세탁기', 'F21VDP', 'LG-WASH-F21VDP', 'LG', 1980000, 39200, '세탁과 탈수를 동시에 LG 트윈워시', FALSE, 2)
+     , ('건조기', '삼성 AI 건조기', 'DV90T8240SH', 'SAM-DRY-DV90T8240SH', '삼성', 1790000, 36500, 'AI 제어 삼성 건조기', FALSE, 2)
+     , ('에어컨', '무풍에어컨 클래식', 'AF17A6474TZ', 'SAM-AC-AF17A6474TZ', '삼성', 2650000, 49500, '무풍 냉방 삼성 에어컨', FALSE, 2)
+     , ('청소기', '코드제로 A9S', 'A958VA', 'LG-VAC-A958VA', 'LG', 1190000, 24500, 'LG 코드제로 무선 청소기', FALSE, 2)
+     , ('오븐', 'LG 광파오븐 MA324B', 'MA324B', 'LG-OVEN-MA324B', 'LG', 540000, 11900, '간편한 요리를 위한 LG 오븐', FALSE, 2)
+     , ('식기세척기', '삼성 비스포크 식기세척기', 'DW60A8055UG', 'SAM-DISH-DW60A8055UG', '삼성', 1450000, 29900, '스마트 기능 탑재 식기세척기', FALSE, 2)
+     , ('공기청정기', 'LG 퓨리케어 360° 공기청정기', 'AS351NNFA', 'LG-AP-AS351NNFA', 'LG', 1040000, 20900, '360도 청정 기능 LG 공기청정기', FALSE, 2)
+     , ('공기청정기', '삼성 블루스카이 5000', 'AX60A5510WDD', 'SAM-AP-AX60A5510WDD', '삼성', 980000, 19900, '초미세먼지 제거 삼성 공기청정기', FALSE, 2)
+     , ('전자레인지', 'LG 전자레인지 MW25S', 'MW25S', 'LG-MIW-MW25S', 'LG', 210000, 4900, '간단 요리를 위한 전자레인지', FALSE, 2)
+     , ('제습기', '삼성 무풍 제습기', 'AY10R5171', 'SAM-DEH-AY10R5171', '삼성', 670000, 13900, '쾌적한 여름을 위한 삼성 제습기', FALSE, 2);
 
 -- NOTICE
 INSERT INTO NOTICE (id, title, content, created_at, is_deleted, employee_id)

--- a/src/main/java/com/clover/salad/product/query/service/ProductQueryServiceImpl.java
+++ b/src/main/java/com/clover/salad/product/query/service/ProductQueryServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.clover.salad.common.exception.NotFoundException;
 import com.clover.salad.product.command.application.dto.ProductDTO;
 import com.clover.salad.product.command.application.dto.SearchTermDTO;
 import com.clover.salad.product.query.mapper.ProductMapper;
@@ -19,7 +20,12 @@ public class ProductQueryServiceImpl implements ProductQueryService {
 	
 	@Override
 	public ProductDTO searchProductById(int productId) {
-		return productMapper.selectProductById(productId);
+		ProductDTO product = productMapper.selectProductById(productId);
+		if (product != null) {
+			return product;
+		} else {
+			throw new NotFoundException("상품 검색 실패");
+		}
 	}
 	
 	@Override

--- a/src/main/resources/com/clover/salad/product/query/mapper/ProductMapper.xml
+++ b/src/main/resources/com/clover/salad/product/query/mapper/ProductMapper.xml
@@ -34,13 +34,16 @@
              , P.RENTAL_COST
              , P.DESCRIPTION
              , P.IS_DELETED
-             , P.FILE_UPLOAD_ID
-             , F.RENAME_FILE AS FILE_NAME
-             , F.PATH AS FILE_URL
+             , CASE
+                   WHEN F.ID IS NULL THEN 2
+                   ELSE F.ID
+               END AS FILE_UPLOAD_ID
+             , COALESCE(F.RENAME_FILE, F2.RENAME_FILE) AS FILE_NAME
+             , COALESCE(F.PATH, F2.PATH) AS FILE_URL
           FROM PRODUCT P
-          JOIN FILE_UPLOAD F
-            ON P.FILE_UPLOAD_ID = F.ID
-         WHERE P.ID = #{productId}
+     LEFT JOIN FILE_UPLOAD F ON P.FILE_UPLOAD_ID = F.ID
+     LEFT JOIN FILE_UPLOAD F2 ON F.ID IS NULL AND F2.ID = 2
+         WHERE P.ID = #{productId};
     </select>
 
     <!-- 설명. 상품 목록 조회 -->


### PR DESCRIPTION
## 📝작업 내용

- Refactor: 상품 상세 조회 시 검색 결과 없으면 예외처리

- Refactor: 현재 저장된 파일 fk가 파일 테이블에 없으면 상품 기본 이미지(2번 이미지)로 조회

- Chore: 상품 기본 이미지 추가
  - 사원 기본 이미지와 상품 기본 이미지가 항상 1번, 2번이도록 id도 지정해서 insert하도록 변경

- Chore: 상품 이미지 id 2로 변경 

  - 추후 파일 더미 데이터 추가 시 잘못된 사진이 출력되는 것을 방지하기 위해 2로 변경

이미 저장되어 있는 더미 데이터로 상품 이미지 출력되는거 확인하시고 더미 새로 갱신하시면 됩니다